### PR TITLE
Tweak error handling from API

### DIFF
--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -16,16 +16,15 @@ const DashboardHeader = () => {
   const fetchUserData = () => {
     const dataUri = `${backendBaseUri[process.env.NODE_ENV]}/users/current`
 
-    fetch(dataUri, {
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${cookies[sessionCookieName]}`
-      }
-    })
+    if (!!cookies[sessionCookieName]) {
+      fetch(dataUri, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${cookies[sessionCookieName]}`
+        }
+      })
       .then(response => {
         if (response.status === 401) {
-          removeCookie(sessionCookieName)
-          setShouldRedirect(true)
           return null
         } else {
           return response.json()
@@ -34,11 +33,19 @@ const DashboardHeader = () => {
       .then(data => {
         if (!!data) {
           setUserData(data)
+          setShouldRedirect(false)
         } else {
+          removeCookie(sessionCookieName)
           setShouldRedirect(true)
         }
       })
-      .catch(() => setShouldRedirect(true))
+      .catch(() => {
+        cookies[sessionCookieName] && removeCookie(sessionCookieName)
+        setShouldRedirect(true)
+      })
+    } else {
+      setShouldRedirect(true)
+    }
   }
 
   useEffect(fetchUserData, [cookies, removeCookie])
@@ -62,9 +69,9 @@ const DashboardHeader = () => {
         </button> :
         null
         }
-          <LogoutDropdown
-            className={dropdownVisible ? styles.logoutDropdown : styles.hidden}
-          />
+        <LogoutDropdown
+          className={dropdownVisible ? styles.logoutDropdown : styles.hidden}
+        />
       </div>
     </div>
   )

--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -16,7 +16,7 @@ const DashboardHeader = () => {
   const fetchUserData = () => {
     const dataUri = `${backendBaseUri[process.env.NODE_ENV]}/users/current`
 
-    if (!!cookies[sessionCookieName]) {
+    if (typeof global.process === 'undefined' || !!cookies[sessionCookieName]) {
       fetch(dataUri, {
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -17,6 +17,7 @@ const DashboardHeader = () => {
   const fetchUserData = () => {
     const dataUri = `${backendBaseUri[process.env.NODE_ENV]}/users/current`
 
+    // typeof global.process === 'undefined' when it's storybook
     if (mountedRef.current === true && (typeof global.process === 'undefined' || !!cookies[sessionCookieName])) {
       fetch(dataUri, {
         headers: {

--- a/src/components/logoutDropdown/logoutDropdown.js
+++ b/src/components/logoutDropdown/logoutDropdown.js
@@ -1,26 +1,8 @@
 import React from 'react'
-import { Redirect } from 'react-router-dom'
-import { useCookies } from 'react-cookie'
-import paths from '../../routing/paths'
-import { sessionCookieName } from '../../utils/config'
 import icon from './googleIcon.svg'
 import styles from './logoutDropdown.module.css'
 
-const LogoutDropdown = ({className}) => {
-  const [cookies, , removeCookie] = useCookies([sessionCookieName])
-
-  const logOutUser = () => {
-    const googleUri = 'https://accounts.google.com/o/oauth2/revoke?token=' + cookies[sessionCookieName]
-    
-    fetch(googleUri, {
-      headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-     }
-    }).then(() => {
-      removeCookie(sessionCookieName)
-      return <Redirect to={paths.home} />
-    })
-  }
+const LogoutDropdown = ({className, logOutUser}) => {
 
   return(
     <div className={className}>

--- a/src/components/logoutDropdown/logoutDropdown.js
+++ b/src/components/logoutDropdown/logoutDropdown.js
@@ -16,7 +16,7 @@ const LogoutDropdown = ({className}) => {
       headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
      }
-    }).then((resp) => {
+    }).then(() => {
       removeCookie(sessionCookieName)
       return <Redirect to={paths.home} />
     })

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -23,7 +23,6 @@ const LoginPage = () => {
     if (cookies[sessionCookieName] !== tokenId) {
       fetch(backendUri, {
         headers: {
-          'Content-Type': 'application/json',
           'Authorization': `Bearer ${tokenId}`
         }
       })

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -27,22 +27,23 @@ const LoginPage = () => {
         }
       })
       .then(response => {
-        if (response.ok === true) {
+        if (response.status === 204) {
           setCookie(sessionCookieName, tokenId)
         } else {
-          if (cookies[sessionCookieName]) { removeCookie(sessionCookieName) }
+          !!cookies[sessionCookieName] && removeCookie(sessionCookieName)
         }
       })
-      .catch(error => console.log(error))
+      .catch(error => {
+        !!cookies[sessionCookieName] && removeCookie(sessionCookieName)
+        console.log('Error from /auth/verify_token: ', error)
+        return <Redirect to={paths.home} />
+      })
     }
   }
 
   const failureCallback = (resp) => {
     console.log('Login failure: ', resp)
-
-    if (!!cookies[sessionCookieName]) {
-      removeCookie(sessionCookieName)
-    }
+    !!cookies[sessionCookieName] && removeCookie(sessionCookieName)
   }
 
   return(!!cookies[sessionCookieName] ?

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Redirect } from 'react-router-dom'
 import GoogleLogin from 'react-google-login'
 import { useCookies } from 'react-cookie'
@@ -13,6 +13,7 @@ import styles from './login.module.css'
 
 const LoginPage = () => {
   const [cookies, setCookie, removeCookie] = useCookies([sessionCookieName])
+  const [loginErrorMessage, setLoginErrorMessage] = useState(null)
 
   const successCallback = (resp) => {
     const { tokenId } = resp
@@ -44,11 +45,15 @@ const LoginPage = () => {
   const failureCallback = (resp) => {
     console.log('Login failure: ', resp)
     !!cookies[sessionCookieName] && removeCookie(sessionCookieName)
+    setLoginErrorMessage('Something went wrong! Please try logging in again.')
   }
 
   return(!!cookies[sessionCookieName] ?
     <Redirect to={paths.dashboard.main} /> :
     <div className={styles.root}>
+      {loginErrorMessage ?
+      <p className={styles.errorMessage}>{loginErrorMessage}</p> :
+      null}
       <div className={styles.container}>
         <GoogleLogin
           className={styles.button}

--- a/src/pages/login.module.css
+++ b/src/pages/login.module.css
@@ -4,6 +4,11 @@
   display: grid;
 }
 
+.errorMessage {
+  margin: 64px auto 0;
+  color: #ff0000;
+}
+
 .container {
   display: grid;
   margin: auto;


### PR DESCRIPTION
## Context

[**Implement better handling of API error responses**](https://trello.com/c/9o8dkCTD/9-implement-better-handling-of-api-error-responses)

I had implemented a kind of down-and-dirty handling of API calls to the backend, especially with regards to error handling. They turned out to not be as bad as I thought but still needed a little bit of tweaking. This PR improves them.

## Changes

* In `DashboardHeader` component, only fetch backend data if the google auth cookie is set, otherwise we know it's going to fail anyway so what's the point
* Clean up code a bit and call `removeCookie` in more logical places (it was called in both promises so I just set it in the second one)
* Check for 204 response from `/auth/verify_token` endpoint instead of `response.ok` - 204 is the only success response from that endpoint and if we're getting something else we shouldn't be logging the user in
* Fix up login a little bit - now it doesn't make further requests to `/users/current` after logout or leave console errors anymore

## NB

When the user logs out, it still goes to the login page and not the homepage like the code is supposed to. I'm not sure what's going on and am not sure that that issue should be a priority compared to other cards on this project.