### PR TITLE
Create shopping list page + several UI improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-loading": "^2.0.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "react-slide-toggle": "^0.3.5",
     "web-vitals": "^1.0.1"
   },
   "scripts": {

--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -26,20 +26,17 @@ const DashboardHeader = () => {
           'Authorization': `Bearer ${cookies[sessionCookieName]}`
         }
       })
-      .then(response => {
-        if (response.status === 401) {
-          return null
-        } else {
-          return response.json()
-        }
-      })
+      .then(response => (response.json()))
       .then(data => {
-        if (!!data) {
-          setUserData(data)
-          setShouldRedirect(false)
-        } else {
+        if (!data) {
+          setShouldRedirect(true)
+        } else if (data.error) {
+          console.warn('Error fetching user data - logging out user: ', data.error)
           removeCookie(sessionCookieName)
           setShouldRedirect(true)
+        } else {
+          setUserData(data)
+          setShouldRedirect(false)
         }
       })
       .catch(() => {

--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -7,6 +7,8 @@ import LogoutDropdown from '../logoutDropdown/logoutDropdown'
 import anonymousAvatar from './anonymousAvatar.jpg'
 import styles from './dashboardHeader.module.css'
 
+const isStorybook = typeof global.process === 'undefined'
+
 const DashboardHeader = () => {
   const [dropdownVisible, setDropdownVisible] = useState(false)
   const [cookies, , removeCookie] = useCookies([sessionCookieName])
@@ -17,8 +19,7 @@ const DashboardHeader = () => {
   const fetchUserData = () => {
     const dataUri = `${backendBaseUri[process.env.NODE_ENV]}/users/current`
 
-    // typeof global.process === 'undefined' when it's storybook
-    if (mountedRef.current === true && (typeof global.process === 'undefined' || !!cookies[sessionCookieName])) {
+    if (mountedRef.current === true && (isStorybook || !!cookies[sessionCookieName])) {
       fetch(dataUri, {
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { useCookies } from 'react-cookie'
-import { Redirect } from 'react-router-dom'
+import { Link, Redirect } from 'react-router-dom'
 import paths from '../../routing/paths'
 import { sessionCookieName, backendBaseUri } from '../../utils/config'
 import LogoutDropdown from '../logoutDropdown/logoutDropdown'
@@ -83,7 +83,7 @@ const DashboardHeader = () => {
       <div className={styles.bar}>
         <span className={styles.headerContainer}>
           <h1 className={styles.header}>
-            Skyrim Inventory<br className={styles.bp} /> Management
+            <Link className={styles.headerLink} to={paths.dashboard.main}>Skyrim Inventory<br className={styles.bp} /> Management</Link>
           </h1>
         </span>
         {!!userData ?

--- a/src/components/dashboardHeader/dashboardHeader.module.css
+++ b/src/components/dashboardHeader/dashboardHeader.module.css
@@ -25,6 +25,11 @@
   font-size: 1.5rem;
 }
 
+.headerLink {
+  text-decoration: none;
+  color: #fff;
+}
+
 .profile {
   background-color: #000;
   border: none;

--- a/src/components/dashboardHeader/dashboardHeader.module.css
+++ b/src/components/dashboardHeader/dashboardHeader.module.css
@@ -5,7 +5,7 @@
 }
 
 .bar {
-  width: 100%;
+  max-width: 100%;
   height: 64px;
   padding: 12px 16px;
   background-color: #000;
@@ -34,14 +34,12 @@
   background-color: #000;
   border: none;
   display: grid;
-  align-items: center;
   grid-template-columns: 2fr 1fr;
-  max-width: 30%;
   cursor: pointer;
-  margin-right: 16px;
 }
 
 .profileText {
+  margin: auto 0;
   display: grid;
 }
 
@@ -67,7 +65,6 @@
   border-radius: 50%;
   box-shadow: 0px 0px 12px #fff;
   margin-left: 24px;
-  margin-right: 16px;
 }
 
 .logoutDropdown {
@@ -82,7 +79,7 @@
   display: none;
 }
 
-@media (min-width: 425px) {
+@media (min-width: 768px) {
   .bp {
     display: none;
   }

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ReactLoading from 'react-loading'
+
+const possibleTypes = [
+  'blank',
+  'balls',
+  'bars',
+  'bubbles',
+  'cubes',
+  'cylon',
+  'spin',
+  'spinningBubbles',
+  'spokes'
+]
+
+const Loading = ({ type = 'spin', color, height, width }) => (
+  <ReactLoading type={type} color={color} height={height} width={width} />
+)
+
+Loading.propTypes = {
+  type: PropTypes.oneOf(possibleTypes),
+  color: PropTypes.string.isRequired,
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  width: PropTypes.number.isRequired
+}
+
+export default Loading

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -14,15 +14,16 @@ const possibleTypes = [
   'spokes'
 ]
 
-const Loading = ({ type = 'spin', color, height, width }) => (
-  <ReactLoading type={type} color={color} height={height} width={width} />
+const Loading = ({ className, type = 'spin', color, height, width }) => (
+  <ReactLoading className={className} type={type} color={color} height={height} width={width} />
 )
 
 Loading.propTypes = {
+  className: PropTypes.string.isRequired,
   type: PropTypes.oneOf(possibleTypes),
   color: PropTypes.string.isRequired,
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  width: PropTypes.number.isRequired
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
 }
 
 export default Loading

--- a/src/components/loading/loading.stories.js
+++ b/src/components/loading/loading.stories.js
@@ -1,0 +1,86 @@
+import React from 'react'
+import { AQUA } from '../../utils/colorSchemes'
+import Loading from './loading'
+
+export default { title: 'Loading' }
+
+export const Blank = () => (
+  <Loading
+    type='blank'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)
+
+export const Balls = () => (
+  <Loading
+    type='balls'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)
+
+export const Bars = () => (
+  <Loading
+    type='bars'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)
+
+export const Bubbles = () => (
+  <Loading
+    type='bubbles'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)
+
+export const Cubes = () => (
+  <Loading
+    type='cubes'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)
+
+export const Cylon = () => (
+  <Loading
+    type='cylon'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)
+
+export const Spin = () => (
+  <Loading
+    type='spin'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)
+
+export const SpinningBubbles = () => (
+  <Loading
+    type='spinningBubbles'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)
+
+export const Spokes = () => (
+  <Loading
+    type='spokes'
+    color={AQUA.schemeColor}
+    height={667}
+    width={375}
+  />
+)

--- a/src/components/logoutDropdown/logoutDropdown.js
+++ b/src/components/logoutDropdown/logoutDropdown.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import icon from './googleIcon.svg'
 import styles from './logoutDropdown.module.css'
 
@@ -14,5 +15,10 @@ const LogoutDropdown = ({className, logOutUser}) => (
     </button>
   </div>
 )
+
+LogoutDropdown.propTypes = {
+  className: PropTypes.string.isRequired,
+  logOutUser: PropTypes.func.isRequired
+}
 
 export default LogoutDropdown

--- a/src/components/logoutDropdown/logoutDropdown.js
+++ b/src/components/logoutDropdown/logoutDropdown.js
@@ -2,20 +2,17 @@ import React from 'react'
 import icon from './googleIcon.svg'
 import styles from './logoutDropdown.module.css'
 
-const LogoutDropdown = ({className, logOutUser}) => {
-
-  return(
-    <div className={className}>
-      <button className={styles.button} onClick={logOutUser}>
-        <div className={styles.body}>
-          <div className={styles.googleLogout}>
-            <img src={icon} alt='Google logo' />
-            Log Out With Google
-          </div>
+const LogoutDropdown = ({className, logOutUser}) => (
+  <div className={className}>
+    <button className={styles.button} onClick={logOutUser}>
+      <div className={styles.body}>
+        <div className={styles.googleLogout}>
+          <img src={icon} alt='Google logo' />
+          Log Out With Google
         </div>
-      </button>
-    </div>
-  )
-}
+      </div>
+    </button>
+  </div>
+)
 
 export default LogoutDropdown

--- a/src/components/navigationCard/navigationCard.js
+++ b/src/components/navigationCard/navigationCard.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import styles from './navigationCard.module.css'
 
@@ -14,6 +15,22 @@ const NavigationCard = ({ colorScheme, href, children }) => {
       {children}
     </Link>
   )
+}
+
+NavigationCard.propTypes = {
+  colorScheme: PropTypes.shape({
+    schemeColor: PropTypes.string.isRequired,
+    hoverColor: PropTypes.string.isRequired,
+    textColorPrimary: PropTypes.string.isRequired,
+    borderColor: PropTypes.string,
+    schemeColorLighter: PropTypes.string,
+    hoverColorLighter: PropTypes.string,
+    schemeColorLightest: PropTypes.string,
+    textColorSecondary: PropTypes.string,
+    textColorTertiary: PropTypes.string
+  }).isRequired,
+  href: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired
 }
 
 export default NavigationCard

--- a/src/components/navigationCard/navigationCard.js
+++ b/src/components/navigationCard/navigationCard.js
@@ -2,10 +2,18 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import styles from './navigationCard.module.css'
 
-const NavigationCard = ({ backgroundColor, textColor, href, children }) => (
-  <Link className={styles.root} to={href} style={{'--background-color': backgroundColor, '--text-color': textColor}}>
-    {children}
-  </Link>
-)
+const NavigationCard = ({ colorScheme, href, children }) => {
+  const styleVars = {
+    '--background-color': colorScheme.schemeColor,
+    '--hover-color': colorScheme.hoverColor,
+    '--text-color': colorScheme.textColorPrimary
+  }
+
+  return(
+    <Link className={styles.root} to={href} style={styleVars}>
+      {children}
+    </Link>
+  )
+}
 
 export default NavigationCard

--- a/src/components/navigationCard/navigationCard.module.css
+++ b/src/components/navigationCard/navigationCard.module.css
@@ -15,5 +15,5 @@
 
 .root:hover {
   text-decoration: underline;
-  filter: brightness(95%);
+  background-color: var(--hover-color)
 }

--- a/src/components/navigationCard/navigationCard.stories.js
+++ b/src/components/navigationCard/navigationCard.stories.js
@@ -1,10 +1,11 @@
 import React from 'react'
+import { GREEN } from '../../utils/colorSchemes'
 import NavigationCard from './navigationCard'
 
 export default { title: 'NavigationCard' }
 
 export const Default = () => (
-  <NavigationCard backgroundColor='#E83F6F' textColor='#FFFFFF' href='#'>
+  <NavigationCard colorScheme={GREEN} href='#'>
     Your Shopping List
   </NavigationCard>
 )

--- a/src/components/navigationMosaic/navigationMosaic.js
+++ b/src/components/navigationMosaic/navigationMosaic.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import NavigationCard from '../navigationCard/navigationCard'
 import styles from './navigationMosaic.module.css'
 
@@ -15,5 +16,26 @@ const NavigationMosaic = ({ cardArray }) => (
     ))}
   </div>
 )
+
+NavigationMosaic.propTypes = {
+  cardArray: PropTypes.arrayOf(
+    PropTypes.shape({
+      href: PropTypes.string.isRequired,
+      children: PropTypes.node.isRequired,
+      key: PropTypes.string.isRequired,
+      colorScheme: PropTypes.shape({
+        schemeColor: PropTypes.string.isRequired,
+        hoverColor: PropTypes.string.isRequired,
+        textColorPrimary: PropTypes.string.isRequired,
+        borderColor: PropTypes.string,
+        schemeColorLighter: PropTypes.string,
+        hoverColorLighter: PropTypes.string,
+        schemeColorLightest: PropTypes.string,
+        textColorSecondary: PropTypes.string,
+        textColorTertiary: PropTypes.string
+      }).isRequired
+    })
+  ).isRequired
+}
 
 export default NavigationMosaic

--- a/src/components/navigationMosaic/navigationMosaic.js
+++ b/src/components/navigationMosaic/navigationMosaic.js
@@ -4,11 +4,10 @@ import styles from './navigationMosaic.module.css'
 
 const NavigationMosaic = ({ cardArray }) => (
   <div className={styles.root}>
-    {cardArray.map(({ backgroundColor, textColor, href, children, key }) => (
+    {cardArray.map(({ colorScheme, href, children, key }) => (
       <div key={key} className={styles.card}>
         <NavigationCard 
-          backgroundColor={backgroundColor}
-          textColor={textColor}
+          colorScheme={colorScheme}
           href={href}
           children={children}
         />

--- a/src/components/navigationMosaic/navigationMosaic.stories.js
+++ b/src/components/navigationMosaic/navigationMosaic.stories.js
@@ -6,7 +6,7 @@ const cards = [
     backgroundColor: '#FFBF00',
     textColor: '#000000',
     href: '#',
-    children: 'Nav Link 1',
+    children: 'Your Shopping Lists',
     key: 'card-1'
   },
   {

--- a/src/components/navigationMosaic/navigationMosaic.stories.js
+++ b/src/components/navigationMosaic/navigationMosaic.stories.js
@@ -1,38 +1,40 @@
 import React from 'react'
+import {
+  YELLOW,
+  PINK,
+  BLUE,
+  GREEN,
+  AQUA
+} from '../../utils/colorSchemes'
 import NavigationMosaic from './navigationMosaic'
 
 const cards = [
   {
-    backgroundColor: '#FFBF00',
-    textColor: '#000000',
+    colorScheme: YELLOW,
     href: '#',
     children: 'Your Shopping Lists',
     key: 'card-1'
   },
   {
-    backgroundColor: '#E83F6F',
-    textColor: '#FFFFFF',
+    colorScheme: PINK,
     href: '#',
     children: 'Nav Link 2',
     key: 'card-2'
   },
   {
-    backgroundColor: '#2274A5',
-    textColor: '#FFFFFF',
+    colorScheme: BLUE,
     href: '#',
     children: 'Nav Link 3',
     key: 'card-3'
   },
   {
-    backgroundColor: '#00A323',
-    textColor: '#FFFFFF',
+    colorScheme: GREEN,
     href: '#',
     children: 'Nav Link 4',
     key: 'card-4'
   },
   {
-    backgroundColor: '#20E2E9',
-    textColor: '#000000',
+    colorScheme: AQUA,
     href: '#',
     children: 'Nav Link 5',
     key: 'card-5'

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -71,7 +71,17 @@ const ShoppingList = ({ title, colorScheme, listItems = [] }) => {
 
 ShoppingList.propTypes = {
   title: PropTypes.string.isRequired,
-  colorScheme: PropTypes.shape.isRequired,
+  colorScheme: PropTypes.shape({
+    schemeColor: PropTypes.string.isRequired,
+    hoverColor: PropTypes.string.isRequired,
+    borderColor: PropTypes.string.isRequired,
+    textColorPrimary: PropTypes.string.isRequired,
+    schemeColorLighter: PropTypes.string.isRequired,
+    hoverColorLighter: PropTypes.string.isRequired,
+    schemeColorLightest: PropTypes.string.isRequired,
+    textColorSecondary: PropTypes.string.isRequired,
+    textColorTertiary: PropTypes.string.isRequired
+  }).isRequired,
   listItems: PropTypes.arrayOf(PropTypes.shape).isRequired
 }
 

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -6,25 +6,24 @@ import styles from './shoppingList.module.css'
 
 const ShoppingList = ({ title, colorScheme, listItems = [] }) => {
   const {
-    outerColor,
-    borderColor,
-    textColor,
+    schemeColor,
     hoverColor,
-    listItemHeaderColor,
-    listItemHoverColor,
-    listItemBorderColor,
-    listItemBodyBackgroundColor,
-    listItemTitleTextColor,
-    listItemBodyTextColor
+    borderColor,
+    textColorPrimary,
+    schemeColorLighter,
+    hoverColorLighter,
+    schemeColorLightest,
+    textColorSecondary,
+    textColorTertiary,
   } = colorScheme
 
   const listItemColorScheme = {
-    schemeColor: listItemHeaderColor,
-    hoverColor: listItemHoverColor,
-    borderColor: listItemBorderColor,
-    titleTextColor: listItemTitleTextColor,
-    bodyBackgroundColor: listItemBodyBackgroundColor,
-    bodyTextColor: listItemBodyTextColor
+    schemeColor: schemeColorLighter,
+    hoverColor: hoverColorLighter,
+    borderColor: borderColor,
+    titleTextColor: textColorSecondary,
+    bodyBackgroundColor: schemeColorLightest,
+    bodyTextColor: textColorTertiary
   }
 
   const [toggleEvent, setToggleEvent] = useState(0)
@@ -34,9 +33,9 @@ const ShoppingList = ({ title, colorScheme, listItems = [] }) => {
   }
 
   const styleVars = {
-    '--scheme-color': outerColor,
+    '--scheme-color': schemeColor,
     '--border-color': borderColor,
-    '--text-color': textColor,
+    '--text-color': textColorPrimary,
     '--hover-color': hoverColor
   }
 

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -1,0 +1,75 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import SlideToggle from 'react-slide-toggle'
+import ShoppingListItem from '../shoppingListItem/shoppingListItem'
+import styles from './shoppingList.module.css'
+
+const ShoppingList = ({ title, colorScheme, listItems = [] }) => {
+  const {
+    outerColor,
+    borderColor,
+    textColor,
+    hoverColor,
+    listItemHeaderColor,
+    listItemHoverColor,
+    listItemBorderColor,
+    listItemBodyBackgroundColor,
+    listItemTitleTextColor,
+    listItemBodyTextColor
+  } = colorScheme
+
+  const listItemColorScheme = {
+    schemeColor: listItemHeaderColor,
+    hoverColor: listItemHoverColor,
+    borderColor: listItemBorderColor,
+    titleTextColor: listItemTitleTextColor,
+    bodyBackgroundColor: listItemBodyBackgroundColor,
+    bodyTextColor: listItemBodyTextColor
+  }
+
+  const [toggleEvent, setToggleEvent] = useState(0)
+
+  const toggleListItems = () => {
+    setToggleEvent(Date.now)
+  }
+
+  const styleVars = {
+    '--scheme-color': outerColor,
+    '--border-color': borderColor,
+    '--text-color': textColor,
+    '--hover-color': hoverColor
+  }
+
+  return(
+    <div className={styles.root} style={styleVars}>
+      <div className={styles.titleContainer}>
+        <button className={styles.button} onClick={toggleListItems}>
+          <h3 className={styles.title}>{title}</h3>
+        </button>
+      </div>
+      <SlideToggle toggleEvent={toggleEvent} collapsed>
+        {({ setCollapsibleElement }) => (
+          <div className={styles.collapsible} ref={setCollapsibleElement}>
+            {listItems.map(({ id, description, quantity, notes }) => (
+              <ShoppingListItem
+                key={`shopping-list-item-${id}`}
+                description={description}
+                quantity={quantity}
+                notes={notes}
+                colorScheme={listItemColorScheme}
+              />
+            ))}
+          </div>
+        )}
+      </SlideToggle>
+    </div>
+  )
+}
+
+ShoppingList.propTypes = {
+  title: PropTypes.string.isRequired,
+  colorScheme: PropTypes.shape.isRequired,
+  listItems: PropTypes.arrayOf(PropTypes.shape).isRequired
+}
+
+export default ShoppingList

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -49,15 +49,19 @@ const ShoppingList = ({ title, colorScheme, listItems = [] }) => {
       <SlideToggle toggleEvent={toggleEvent} collapsed>
         {({ setCollapsibleElement }) => (
           <div className={styles.collapsible} ref={setCollapsibleElement}>
-            {listItems.map(({ id, description, quantity, notes }) => (
-              <ShoppingListItem
-                key={`shopping-list-item-${id}`}
-                description={description}
-                quantity={quantity}
-                notes={notes}
-                colorScheme={listItemColorScheme}
-              />
-            ))}
+            {listItems.map(({ id, description, quantity, notes }) => {
+              const itemKey = `${title.toLowerCase().replace(' ', '-')}-${id}`
+
+              return(
+                <ShoppingListItem
+                  key={itemKey}
+                  description={description}
+                  quantity={quantity}
+                  notes={notes}
+                  colorScheme={listItemColorScheme}
+                />
+              )
+            })}
           </div>
         )}
       </SlideToggle>

--- a/src/components/shoppingList/shoppingList.module.css
+++ b/src/components/shoppingList/shoppingList.module.css
@@ -1,7 +1,6 @@
 .root {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
   background-color: var(--scheme-color);
-  width: 50%;
   color: var(--text-color);
   border-radius: 8px;
   padding: 8px;
@@ -25,4 +24,16 @@
 
 .collapsible {
   border: 1px solid var(--border-color);
+}
+
+@media (min-width: 768px) {
+  .root {
+    width: 80%;
+  }
+}
+
+@media (min-width: 1024px) {
+  .root {
+    width: 50%;
+  }
 }

--- a/src/components/shoppingList/shoppingList.module.css
+++ b/src/components/shoppingList/shoppingList.module.css
@@ -5,6 +5,7 @@
   color: var(--text-color);
   border-radius: 8px;
   padding: 8px;
+  margin: 0 auto;
 }
 
 .root:hover, .root:hover .button {
@@ -13,6 +14,7 @@
 
 .button {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  font-size: 1.125rem;
   background-color: var(--scheme-color);
   color: var(--text-color);
   width: 100%;

--- a/src/components/shoppingList/shoppingList.module.css
+++ b/src/components/shoppingList/shoppingList.module.css
@@ -1,0 +1,26 @@
+.root {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  background-color: var(--scheme-color);
+  width: 50%;
+  color: var(--text-color);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.root:hover, .root:hover .button {
+  background-color: var(--hover-color);
+}
+
+.button {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  background-color: var(--scheme-color);
+  color: var(--text-color);
+  width: 100%;
+  border: none;
+  cursor: pointer;
+  border-radius: 8px;
+}
+
+.collapsible {
+  border: 1px solid var(--border-color);
+}

--- a/src/components/shoppingList/shoppingList.stories.js
+++ b/src/components/shoppingList/shoppingList.stories.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import ShoppingList from './shoppingList'
+
+const listItems = [
+  {
+    id: 1,
+    shopping_list_id: 1,
+    description: 'Ebony sword',
+    quantity: 3,
+    notes: 'Love those ebony swords'
+  },
+  {
+    id: 2,
+    shopping_list_id: 1,
+    description: 'Necklace',
+    quantity: 4,
+    notes: 'Any unenchanted necklaces for enchanting'
+  },
+  {
+    id: 3,
+    shopping_list_id: 1,
+    description: 'Iron ingot',
+    quantity: 400,
+    notes: 'Building Lakeview Manor takes some iron'
+  }
+]
+
+const colorScheme = {
+  outerColor: '#E83F6F',
+  hoverColor: '#D03863',
+  borderColor: '#B93258',
+  textColor: '#FFFFFF',
+  listItemHeaderColor: '#EC658B',
+  listItemHoverColor: '#EA527D',
+  listItemTitleTextColor: '#FFFFFF',
+  listItemBodyTextColor: '#000000',
+  listItemBodyBackgroundColor: '#FAD8E2'
+}
+
+export default { title: 'ShoppingList' }
+
+export const Default = () => (
+  <ShoppingList
+    title='My List 1'
+    colorScheme={colorScheme}
+    listItems={listItems}
+  />
+)

--- a/src/components/shoppingList/shoppingList.stories.js
+++ b/src/components/shoppingList/shoppingList.stories.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { PINK } from '../../utils/colorSchemes'
 import ShoppingList from './shoppingList'
 
 const listItems = [
@@ -25,24 +26,12 @@ const listItems = [
   }
 ]
 
-const colorScheme = {
-  outerColor: '#E83F6F',
-  hoverColor: '#D03863',
-  borderColor: '#B93258',
-  textColor: '#FFFFFF',
-  listItemHeaderColor: '#EC658B',
-  listItemHoverColor: '#EA527D',
-  listItemTitleTextColor: '#FFFFFF',
-  listItemBodyTextColor: '#000000',
-  listItemBodyBackgroundColor: '#FAD8E2'
-}
-
 export default { title: 'ShoppingList' }
 
 export const Default = () => (
   <ShoppingList
     title='My List 1'
-    colorScheme={colorScheme}
+    colorScheme={PINK}
     listItems={listItems}
   />
 )

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -55,7 +55,14 @@ const ShoppingListItem = ({
 }
 
 ShoppingListItem.propTypes = {
-  colorScheme: PropTypes.shape.isRequired,
+  colorScheme: PropTypes.shape({
+    schemeColor: PropTypes.string.isRequired,
+    hoverColor: PropTypes.string.isRequired,
+    titleTextColor: PropTypes.string.isRequired,
+    borderColor: PropTypes.string.isRequired,
+    bodyBackgroundColor: PropTypes.string.isRequired,
+    bodyTextColor: PropTypes.string.isRequired
+  }).isRequired,
   description: PropTypes.string.isRequired,
   quantity: PropTypes.number.isRequired,
   notes: PropTypes.string

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -10,7 +10,7 @@ const ShoppingListItem = ({
   notes,
   colorScheme
 }) => {
-  const { schemeColor, textColor, borderColor } = colorScheme
+  const { schemeColor, textColor, borderColor, bodyBackgroundColor } = colorScheme
 
   const [toggleEvent, setToggleEvent] = useState(0)
 
@@ -19,9 +19,10 @@ const ShoppingListItem = ({
   }
 
   const styleVars = {
-    '--background-color': schemeColor,
+    '--scheme-color': schemeColor,
     '--text-color': textColor,
-    '--border-color': borderColor
+    '--border-color': borderColor,
+    '--body-background-color': bodyBackgroundColor
   }
 
   return(

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -55,7 +55,6 @@ const ShoppingListItem = ({
 }
 
 ShoppingListItem.propTypes = {
-  className: PropTypes.string.isRequired,
   colorScheme: PropTypes.shape.isRequired,
   description: PropTypes.string.isRequired,
   quantity: PropTypes.number.isRequired,

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import SlideToggle from 'react-slide-toggle'
@@ -10,7 +10,14 @@ const ShoppingListItem = ({
   notes,
   colorScheme
 }) => {
-  const { schemeColor, titleTextColor, borderColor, bodyBackgroundColor, bodyTextColor } = colorScheme
+  const {
+    schemeColor,
+    hoverColor,
+    titleTextColor,
+    borderColor,
+    bodyBackgroundColor,
+    bodyTextColor
+  } = colorScheme
 
   const [toggleEvent, setToggleEvent] = useState(0)
 
@@ -23,12 +30,13 @@ const ShoppingListItem = ({
     '--title-text-color': titleTextColor,
     '--border-color': borderColor,
     '--body-background-color': bodyBackgroundColor,
-    '--body-text-color': bodyTextColor
+    '--body-text-color': bodyTextColor,
+    '--hover-color': hoverColor
   }
 
   return(
     <div className={styles.root} style={styleVars}>
-      <div className={classnames(styles.headerBar, styles.flexItem)}>
+      <div className={styles.headerContainer}>
         <button className={styles.button} onClick={toggleDetails}>
           <h3 className={styles.description}>{description}</h3>
         </button>
@@ -36,9 +44,9 @@ const ShoppingListItem = ({
       </div>
       <SlideToggle toggleEvent={toggleEvent} collapsed>
         {({ setCollapsibleElement }) => (
-          <div className={styles.collapsible}>
-            <div className={styles.collapsibleContent} ref={setCollapsibleElement}>
-              {notes || 'No details available'}
+          <div className={styles.collapsible} ref={setCollapsibleElement}>
+            <div className={styles.container}>
+              <p className={styles.notes}>{notes || 'No details available'}</p>
             </div>
           </div>
         )}

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -1,0 +1,38 @@
+import React, { useState, useRef } from 'react'
+import PropTypes from 'prop-types'
+import SlideToggle from 'react-slide-toggle'
+import styles from './shoppingListItem.module.css'
+
+const ShoppingListItem = ({ description, quantity, notes }) => {
+  const [toggleEvent, setToggleEvent] = useState(0)
+
+  const toggleDetails = () => {
+    setToggleEvent(Date.now)
+  }
+
+  return(
+    <div className={styles.root}>
+      <button className={styles.titleBar} onClick={toggleDetails}>
+        <span><h3 className={styles.description}>{description}</h3></span>
+        <span className={styles.quantity}>{quantity}</span>
+      </button>
+      <SlideToggle toggleEvent={toggleEvent} collapsed>
+        {({ setCollapsibleElement }) => (
+          <div className={styles.collapsible}>
+            <div className={styles.collapsibleContent} ref={setCollapsibleElement}>
+              {notes}
+            </div>
+          </div>
+        )}
+      </SlideToggle>
+    </div>
+  )
+}
+
+ShoppingListItem.propTypes = {
+  description: PropTypes.string.isRequired,
+  quantity: PropTypes.number.isRequired,
+  notes: PropTypes.string
+}
+
+export default ShoppingListItem

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
 import SlideToggle from 'react-slide-toggle'
 import styles from './shoppingListItem.module.css'
 
@@ -38,9 +37,9 @@ const ShoppingListItem = ({
     <div className={styles.root} style={styleVars}>
       <div className={styles.headerContainer}>
         <button className={styles.button} onClick={toggleDetails}>
-          <h3 className={styles.description}>{description}</h3>
+          <h4 className={styles.description}>{description}</h4>
         </button>
-        <span className={classnames(styles.quantity, styles.flexItem)}>{quantity}</span>
+        <span className={styles.quantity}>{quantity}</span>
       </div>
       <SlideToggle toggleEvent={toggleEvent} collapsed>
         {({ setCollapsibleElement }) => (

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -10,7 +10,7 @@ const ShoppingListItem = ({
   notes,
   colorScheme
 }) => {
-  const { schemeColor, textColor, borderColor, bodyBackgroundColor } = colorScheme
+  const { schemeColor, titleTextColor, borderColor, bodyBackgroundColor, bodyTextColor } = colorScheme
 
   const [toggleEvent, setToggleEvent] = useState(0)
 
@@ -20,9 +20,10 @@ const ShoppingListItem = ({
 
   const styleVars = {
     '--scheme-color': schemeColor,
-    '--text-color': textColor,
+    '--title-text-color': titleTextColor,
     '--border-color': borderColor,
-    '--body-background-color': bodyBackgroundColor
+    '--body-background-color': bodyBackgroundColor,
+    '--body-text-color': bodyTextColor
   }
 
   return(

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -1,26 +1,42 @@
 import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
 import SlideToggle from 'react-slide-toggle'
 import styles from './shoppingListItem.module.css'
 
-const ShoppingListItem = ({ description, quantity, notes }) => {
+const ShoppingListItem = ({
+  description,
+  quantity,
+  notes,
+  colorScheme
+}) => {
+  const { schemeColor, textColor, borderColor } = colorScheme
+
   const [toggleEvent, setToggleEvent] = useState(0)
 
   const toggleDetails = () => {
     setToggleEvent(Date.now)
   }
 
+  const styleVars = {
+    '--background-color': schemeColor,
+    '--text-color': textColor,
+    '--border-color': borderColor
+  }
+
   return(
-    <div className={styles.root}>
-      <button className={styles.titleBar} onClick={toggleDetails}>
-        <span><h3 className={styles.description}>{description}</h3></span>
-        <span className={styles.quantity}>{quantity}</span>
-      </button>
+    <div className={styles.root} style={styleVars}>
+      <div className={classnames(styles.headerBar, styles.flexItem)}>
+        <button className={styles.button} onClick={toggleDetails}>
+          <h3 className={styles.description}>{description}</h3>
+        </button>
+        <span className={classnames(styles.quantity, styles.flexItem)}>{quantity}</span>
+      </div>
       <SlideToggle toggleEvent={toggleEvent} collapsed>
         {({ setCollapsibleElement }) => (
           <div className={styles.collapsible}>
             <div className={styles.collapsibleContent} ref={setCollapsibleElement}>
-              {notes}
+              {notes || 'No details available'}
             </div>
           </div>
         )}
@@ -30,6 +46,8 @@ const ShoppingListItem = ({ description, quantity, notes }) => {
 }
 
 ShoppingListItem.propTypes = {
+  className: PropTypes.string.isRequired,
+  colorScheme: PropTypes.shape.isRequired,
   description: PropTypes.string.isRequired,
   quantity: PropTypes.number.isRequired,
   notes: PropTypes.string

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -1,33 +1,35 @@
 .root {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
-  background-color: var(--background-color);
-  border-radius: 8px;
+  background-color: var(--scheme-color);
 }
 
 .headerBar {
   width: 100%;
+  border-top: 1px solid var(--border-color);
   border-bottom: 1px solid var(--border-color);
   display: grid;
-  grid-template-columns: 3fr 1fr;
+  grid-template-columns: 5fr 1fr;
 }
 
 .button {
   background: none;
   border: none;
+  padding: 0;
   text-align: left;
-  margin-left: 0;
-}
-
-.description {
-  margin-left: 32px;
+  cursor: pointer;
 }
 
 .quantity {
-  margin: auto 32px;
+  margin: auto 0;
   text-align: right;
 }
 
 .description {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
   color: var(--text-color);
+}
+
+.collapsible {
+  background-color: var(--body-background-color);
+  color: #000;
 }

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -3,24 +3,30 @@
   background-color: var(--scheme-color);
 }
 
-.headerBar {
-  width: 100%;
-  border-top: 1px solid var(--border-color);
-  border-bottom: 1px solid var(--border-color);
+.root:hover {
+  background-color: var(--hover-color);
+}
+
+.headerContainer {
   display: grid;
-  grid-template-columns: 5fr 1fr;
+  grid-template-columns: 4fr 1fr;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .button {
   background: none;
   border: none;
+  border-right: 1px solid var(--border-color);
   padding: 0;
   text-align: left;
   cursor: pointer;
+  padding: 32px 0 32px 24px;
 }
 
 .quantity {
+  color: var(--title-text-color);
   margin: auto 0;
+  padding: 0 24px 0 0;
   text-align: right;
 }
 
@@ -33,4 +39,9 @@
 .collapsible {
   background-color: var(--body-background-color);
   color: var(--body-text-color);
+}
+
+.notes {
+  padding: 24px;
+  margin: 0;
 }

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -1,0 +1,33 @@
+.root {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  background-color: var(--background-color);
+  border-radius: 8px;
+}
+
+.headerBar {
+  width: 100%;
+  border-bottom: 1px solid var(--border-color);
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+}
+
+.button {
+  background: none;
+  border: none;
+  text-align: left;
+  margin-left: 0;
+}
+
+.description {
+  margin-left: 32px;
+}
+
+.quantity {
+  margin: auto 32px;
+  text-align: right;
+}
+
+.description {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  color: var(--text-color);
+}

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -26,10 +26,11 @@
 
 .description {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
-  color: var(--text-color);
+  color: var(--title-text-color);
+  margin: 0;
 }
 
 .collapsible {
   background-color: var(--body-background-color);
-  color: #000;
+  color: var(--body-text-color);
 }

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -1,6 +1,7 @@
 .root {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
   background-color: var(--scheme-color);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .root:hover {
@@ -32,6 +33,7 @@
 
 .description {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  font-size: 1.025rem;
   color: var(--title-text-color);
   margin: 0;
 }
@@ -39,6 +41,7 @@
 .collapsible {
   background-color: var(--body-background-color);
   color: var(--body-text-color);
+  border-bottom-color: var(--border-color);
 }
 
 .notes {

--- a/src/components/shoppingListItem/shoppingListItem.stories.js
+++ b/src/components/shoppingListItem/shoppingListItem.stories.js
@@ -1,6 +1,12 @@
 import React from 'react'
 import ShoppingListItem from './shoppingListItem'
 
+const colorScheme = {
+  schemeColor: '#E83F6F',
+  textColor: '#FFFFFF',
+  borderColor: '#B93258'
+}
+
 export default { title: 'ShoppingListItem' }
 
 export const Default = () => (
@@ -8,5 +14,6 @@ export const Default = () => (
     description='Ebony sword'
     quantity={2}
     notes='One to enchant with Soul Trap, one to enchant with Absorb Health'
+    colorScheme={colorScheme}
   />
 )

--- a/src/components/shoppingListItem/shoppingListItem.stories.js
+++ b/src/components/shoppingListItem/shoppingListItem.stories.js
@@ -6,7 +6,8 @@ const colorScheme = {
   titleTextColor: '#FFFFFF',
   bodyTextColor: '#000000',
   borderColor: '#B93258',
-  bodyBackgroundColor: '#FAD8E2'
+  bodyBackgroundColor: '#FAD8E2',
+  hoverColor: '#D03863'
 }
 
 export default { title: 'ShoppingListItem' }

--- a/src/components/shoppingListItem/shoppingListItem.stories.js
+++ b/src/components/shoppingListItem/shoppingListItem.stories.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import ShoppingListItem from './shoppingListItem'
+
+export default { title: 'ShoppingListItem' }
+
+export const Default = () => (
+  <ShoppingListItem
+    description='Ebony sword'
+    quantity={2}
+    notes='One to enchant with Soul Trap, one to enchant with Absorb Health'
+  />
+)

--- a/src/components/shoppingListItem/shoppingListItem.stories.js
+++ b/src/components/shoppingListItem/shoppingListItem.stories.js
@@ -4,7 +4,8 @@ import ShoppingListItem from './shoppingListItem'
 const colorScheme = {
   schemeColor: '#E83F6F',
   textColor: '#FFFFFF',
-  borderColor: '#B93258'
+  borderColor: '#B93258',
+  bodyBackgroundColor: '#FAD8E2'
 }
 
 export default { title: 'ShoppingListItem' }

--- a/src/components/shoppingListItem/shoppingListItem.stories.js
+++ b/src/components/shoppingListItem/shoppingListItem.stories.js
@@ -3,7 +3,8 @@ import ShoppingListItem from './shoppingListItem'
 
 const colorScheme = {
   schemeColor: '#E83F6F',
-  textColor: '#FFFFFF',
+  titleTextColor: '#FFFFFF',
+  bodyTextColor: '#000000',
   borderColor: '#B93258',
   bodyBackgroundColor: '#FAD8E2'
 }

--- a/src/layouts/dashboardLayout.js
+++ b/src/layouts/dashboardLayout.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import DashboardHeader from '../components/dashboardHeader/dashboardHeader'
 import styles from './dashboardLayout.module.css'
 
@@ -17,6 +18,11 @@ const DashboardLayout = ({ title, children }) => {
       <DashboardHeader />
     </div>
   )
+}
+
+DashboardLayout.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.node.isRequired
 }
 
 export default DashboardLayout

--- a/src/layouts/dashboardLayout.js
+++ b/src/layouts/dashboardLayout.js
@@ -6,8 +6,12 @@ const DashboardLayout = ({ title, children }) => {
   return(
     <div className={styles.root}>
       <div className={styles.container}>
-        <h2 className={styles.title}>{title}</h2>
-        <hr className={styles.hr} />
+        {title ?
+        <>
+          <h2 className={styles.title}>{title}</h2>
+          <hr className={styles.hr} />
+        </> :
+        null}
         {children}
       </div>
       <DashboardHeader />

--- a/src/layouts/dashboardLayout.js
+++ b/src/layouts/dashboardLayout.js
@@ -5,7 +5,9 @@ import styles from './dashboardLayout.module.css'
 const DashboardLayout = ({ children }) => {
   return(
     <div className={styles.root}>
-      {children}
+      <div className={styles.container}>
+        {children}
+      </div>
       <DashboardHeader />
     </div>
   )

--- a/src/layouts/dashboardLayout.js
+++ b/src/layouts/dashboardLayout.js
@@ -2,10 +2,12 @@ import React from 'react'
 import DashboardHeader from '../components/dashboardHeader/dashboardHeader'
 import styles from './dashboardLayout.module.css'
 
-const DashboardLayout = ({ children }) => {
+const DashboardLayout = ({ title, children }) => {
   return(
     <div className={styles.root}>
       <div className={styles.container}>
+        <h2 className={styles.title}>{title}</h2>
+        <hr className={styles.hr} />
         {children}
       </div>
       <DashboardHeader />

--- a/src/layouts/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout.module.css
@@ -16,7 +16,7 @@
 }
 
 .container {
-  padding: 128px 0 0;
+  padding: 128px 0;
   margin: 0 auto; 
   max-width: 90%;
 }

--- a/src/layouts/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout.module.css
@@ -2,3 +2,9 @@
   min-height: 100vh;
   background-color: #f5f5f5;
 }
+
+.container {
+  padding: 128px 0 0;
+  margin: 0 auto; 
+  max-width: 90%;
+}

--- a/src/layouts/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout.module.css
@@ -3,6 +3,18 @@
   background-color: #f5f5f5;
 }
 
+.title {
+  font-family: 'Cinzel Decorative', sans-serif;
+}
+
+.hr {
+  border-top-style: none;
+  border-left-style: none;
+  border-right-style: none;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 32px;
+}
+
 .container {
   padding: 128px 0 0;
   margin: 0 auto; 

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -1,41 +1,43 @@
 import React from 'react'
 import paths from '../routing/paths'
+import {
+  YELLOW,
+  PINK,
+  BLUE,
+  GREEN,
+  AQUA
+} from '../utils/colorSchemes'
 import DashboardLayout from '../layouts/dashboardLayout'
 import NavigationMosaic from '../components/navigationMosaic/navigationMosaic'
 import styles from './dashboard.module.css'
 
 const cards = [
   {
-    backgroundColor: '#FFBF00',
-    textColor: '#000000',
+    colorScheme: YELLOW,
     href: paths.dashboard.shoppingLists,
     children: 'Your Shopping Lists',
     key: 'shopping-lists'
   },
   {
-    backgroundColor: '#E83F6F',
-    textColor: '#FFFFFF',
+    colorScheme: PINK,
     href: '#',
     children: 'Nav Link 2',
     key: 'nav-link-2'
   },
   {
-    backgroundColor: '#2274A5',
-    textColor: '#FFFFFF',
+    colorScheme: BLUE,
     href: '#',
     children: 'Nav Link 3',
     key: 'nav-link-3'
   },
   {
-    backgroundColor: '#00A323',
-    textColor: '#FFFFFF',
+    colorScheme: GREEN,
     href: '#',
     children: 'Nav Link 4',
     key: 'nav-link-4'
   },
   {
-    backgroundColor: '#20E2E9',
-    textColor: '#000000',
+    colorScheme: AQUA,
     href: '#',
     children: 'Nav Link 5',
     key: 'nav-link-5'

--- a/src/pages/shoppingList.js
+++ b/src/pages/shoppingList.js
@@ -1,13 +1,19 @@
 import React, { useState, useEffect }from 'react'
 import { useCookies } from 'react-cookie'
-import ShoppingList from '../components/shoppingList/shoppingList'
-import DashboardLayout from '../layouts/dashboardLayout'
 import { backendBaseUri, sessionCookieName } from '../utils/config'
-import colorSchemes from '../utils/colorSchemes'
+import colorSchemes, { YELLOW } from '../utils/colorSchemes'
+import DashboardLayout from '../layouts/dashboardLayout'
+import ShoppingList from '../components/shoppingList/shoppingList'
+import Loading from '../components/loading/loading'
 import styles from './shoppingList.module.css'
+
+const LOADING = 'loading'
+const LOADED = 'loaded'
+const ERROR = 'error'
 
 const ShoppingListPage = () => {
   const [shoppingLists, setShoppingLists] = useState(null)
+  const [loadingState, setLoadingState] = useState(LOADING)
   const [apiError, setApiError] = useState(null)
 
   const [cookies, , ,] = useCookies([sessionCookieName])
@@ -31,8 +37,10 @@ const ShoppingListPage = () => {
       .then(data => {
         if (!!data) {
           if (data.error) {
+            setLoadingState(ERROR)
             setApiError(data.error)
           } else {
+            setLoadingState(LOADED)
             setShoppingLists(data)
           }
         } else {
@@ -46,20 +54,22 @@ const ShoppingListPage = () => {
 
   return(
     <DashboardLayout title='Your Shopping Lists'>
-      <div className={styles.shoppingListContainer}>
-        {!!shoppingLists ?
-          shoppingLists.map(({ title, shopping_list_items }, index) => {
-            const colorSchemesIndex = index > colorSchemes.length ? index % colorSchemes.length : index
-            const listKey = title.toLowerCase().replace(' ', '-')
+      {!!shoppingLists ?
+        shoppingLists.map(({ title, shopping_list_items }, index) => {
+          const colorSchemesIndex = index > colorSchemes.length ? index % colorSchemes.length : index
+          const listKey = title.toLowerCase().replace(' ', '-')
 
-            return(
-              <div className={styles.shoppingList} key={listKey}>
-                <ShoppingList title={title} listItems={shopping_list_items} colorScheme={colorSchemes[colorSchemesIndex]} />
-              </div>
-            )
-          }) :
-        <div className={styles.noLists}>You have no shopping lists.</div>}
-      </div>
+          return(
+            <div className={styles.shoppingList} key={listKey}>
+              <ShoppingList title={title} listItems={shopping_list_items} colorScheme={colorSchemes[colorSchemesIndex]} />
+            </div>
+          )
+        }) :
+        loadingState === LOADING ?
+          <Loading className={styles.loading} type='bubbles' color={YELLOW.schemeColor} height='15%' width='15%' /> :
+          loadingState === ERROR ?
+            <div className={styles.error}>{apiError}</div> :
+            <div>You have no shopping lists.</div>}
     </DashboardLayout>
   )
 }

--- a/src/pages/shoppingList.js
+++ b/src/pages/shoppingList.js
@@ -1,9 +1,68 @@
-import React from 'react'
+import React, { useState, useEffect }from 'react'
+import { useCookies } from 'react-cookie'
+import ShoppingList from '../components/shoppingList/shoppingList'
 import DashboardLayout from '../layouts/dashboardLayout'
+import { backendBaseUri, sessionCookieName } from '../utils/config'
+import colorSchemes from '../utils/colorSchemes'
+import styles from './shoppingList.module.css'
 
-const ShoppingListPage = () => (
-  <DashboardLayout>
-  </DashboardLayout>
-)
+const ShoppingListPage = () => {
+  const [shoppingLists, setShoppingLists] = useState(null)
+  const [apiError, setApiError] = useState(null)
+
+  const [cookies, , ,] = useCookies([sessionCookieName])
+
+  const fetchLists = () => {
+    const dataUri = `${backendBaseUri[process.env.NODE_ENV]}/shopping_lists`
+
+    if (!!cookies[sessionCookieName]) {
+      fetch(dataUri, {
+        headers: {
+          'Authorization': `Bearer ${cookies[sessionCookieName]}`
+        }
+      })
+      .then(response => {
+        if (response.status === 200 || response.status === 401) {
+          return response.json()
+        } else {
+          return null
+        }
+      })
+      .then(data => {
+        if (!!data) {
+          if (data.error) {
+            setApiError(data.error)
+          } else {
+            setShoppingLists(data)
+          }
+        } else {
+          console.warn('Something went wrong')
+        }
+      })
+    }
+  }
+
+  useEffect(fetchLists, [])
+
+  return(
+    <DashboardLayout>
+      <h2 className={styles.title}>Your Shopping Lists</h2>
+      <hr className={styles.hr} />
+      <div className={styles.shoppingListContainer}>
+        {!!shoppingLists ?
+          shoppingLists.map(({ title, shopping_list_items }, index) => {
+            const colorSchemesIndex = index > colorSchemes.length ? index % colorSchemes.length : index
+
+            return(
+              <div className={styles.shoppingList}>
+                <ShoppingList key={title} title={title} listItems={shopping_list_items} colorScheme={colorSchemes[colorSchemesIndex]} />
+              </div>
+            )
+          }) :
+        <div className={styles.noLists}>You have no shopping lists.</div>}
+      </div>
+    </DashboardLayout>
+  )
+}
 
 export default ShoppingListPage

--- a/src/pages/shoppingList.js
+++ b/src/pages/shoppingList.js
@@ -50,10 +50,11 @@ const ShoppingListPage = () => {
         {!!shoppingLists ?
           shoppingLists.map(({ title, shopping_list_items }, index) => {
             const colorSchemesIndex = index > colorSchemes.length ? index % colorSchemes.length : index
+            const listKey = title.toLowerCase().replace(' ', '-')
 
             return(
-              <div className={styles.shoppingList}>
-                <ShoppingList key={title} title={title} listItems={shopping_list_items} colorScheme={colorSchemes[colorSchemesIndex]} />
+              <div className={styles.shoppingList} key={listKey}>
+                <ShoppingList title={title} listItems={shopping_list_items} colorScheme={colorSchemes[colorSchemesIndex]} />
               </div>
             )
           }) :

--- a/src/pages/shoppingList.js
+++ b/src/pages/shoppingList.js
@@ -44,6 +44,8 @@ const ShoppingListPage = () => {
             setShoppingLists(data)
           }
         } else {
+          setLoadingState(ERROR)
+          setApiError('Unknown error: something went wrong when retrieving shopping list data')
           console.warn('Something went wrong')
         }
       })
@@ -56,7 +58,8 @@ const ShoppingListPage = () => {
     <DashboardLayout title='Your Shopping Lists'>
       {!!shoppingLists ?
         shoppingLists.map(({ title, shopping_list_items }, index) => {
-          const colorSchemesIndex = index > colorSchemes.length ? index % colorSchemes.length : index
+          // If there are more lists than colour schemes, cycle through the colour schemes
+          const colorSchemesIndex = index > colorSchemes.length ? (index % colorSchemes.length) : index
           const listKey = title.toLowerCase().replace(' ', '-')
 
           return(
@@ -69,7 +72,7 @@ const ShoppingListPage = () => {
           <Loading className={styles.loading} type='bubbles' color={YELLOW.schemeColor} height='15%' width='15%' /> :
           loadingState === ERROR ?
             <div className={styles.error}>{apiError}</div> :
-            <div>You have no shopping lists.</div>}
+            <p>You have no shopping lists.</p>}
     </DashboardLayout>
   )
 }

--- a/src/pages/shoppingList.js
+++ b/src/pages/shoppingList.js
@@ -45,9 +45,7 @@ const ShoppingListPage = () => {
   useEffect(fetchLists, [])
 
   return(
-    <DashboardLayout>
-      <h2 className={styles.title}>Your Shopping Lists</h2>
-      <hr className={styles.hr} />
+    <DashboardLayout title='Your Shopping Lists'>
       <div className={styles.shoppingListContainer}>
         {!!shoppingLists ?
           shoppingLists.map(({ title, shopping_list_items }, index) => {

--- a/src/pages/shoppingList.module.css
+++ b/src/pages/shoppingList.module.css
@@ -1,0 +1,19 @@
+.title {
+  font-family: 'Cinzel Decorative', sans-serif;
+}
+
+.hr {
+  border-top-style: none;
+  border-left-style: none;
+  border-right-style: none;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 32px;
+}
+
+.shoppingList {
+  margin-bottom: 32px;
+}
+
+.shoppingList:last-of-type {
+  margin-bottom: 0;
+}

--- a/src/pages/shoppingList.module.css
+++ b/src/pages/shoppingList.module.css
@@ -1,15 +1,3 @@
-.title {
-  font-family: 'Cinzel Decorative', sans-serif;
-}
-
-.hr {
-  border-top-style: none;
-  border-left-style: none;
-  border-right-style: none;
-  border-bottom: 1px solid #ccc;
-  margin-bottom: 32px;
-}
-
 .shoppingList {
   margin-bottom: 32px;
 }

--- a/src/pages/shoppingList.module.css
+++ b/src/pages/shoppingList.module.css
@@ -5,3 +5,11 @@
 .shoppingList:last-of-type {
   margin-bottom: 0;
 }
+
+.loading {
+  margin: 0 auto;
+}
+
+.error {
+  color: #ff0000;
+}

--- a/src/utils/colorSchemes.js
+++ b/src/utils/colorSchemes.js
@@ -1,0 +1,66 @@
+export const YELLOW = {
+  schemeColor: '#FFBF00',
+  hoverColor: '#E5AB00',
+  borderColor: '#CC9800',
+  textColorPrimary: '#000000',
+  schemeColorLighter: '#FFCB32',
+  textColorSecondary: '#000000',
+  textColorTertiary: '#000000',
+  schemeColorLightest: '#FFF2CC'
+}
+
+export const PINK = {
+  schemeColor: '#E83F6F',
+  hoverColor: '#D03863',
+  borderColor: '#B93258',
+  textColorPrimary: '#FFFFFF',
+  schemeColorLighter: '#EC658B',
+  hoverColorLighter: '#EA527D',
+  textColorSecondary: '#FFFFFF',
+  textColorTertiary: '#000000',
+  schemeColorLightest: '#FAD8E2'
+}
+
+export const BLUE = {
+  schemeColor: '#2274A5',
+  hoverColor: '#1E6894',
+  borderColor: '#1B5C84',
+  textColorPrimary: '#FFFFFF',
+  schemeColorLighter: '#4E8FB7',
+  hoverColorLighter: '#3881AE',
+  textColorSecondary: '#FFFFFF',
+  textColorTertiary: '#000000',
+  schemeColorLightest: '#D2E3ED'
+}
+
+export const GREEN = {
+  schemeColor: '#00A323',
+  hoverColor: '#00921F',
+  borderColor: '#00821C',
+  textColorPrimary: '#FFFFFF',
+  schemeColorLighter: '#32B54E',
+  hoverColorLighter: '#19AC38',
+  textColorSecondary: '#FFFFFF',
+  textColorTertiary: '#000000',
+  schemeColorLightest: '#CCECD3'
+}
+
+export const AQUA = {
+  schemeColor: '#20E2E9',
+  hoverColor: '#1CCBD1',
+  borderColor: '#19B4BA',
+  textColorPrimary: '#000000',
+  schemeColorLighter: '#62EAEF',
+  hoverColorLighter: '#4CE7ED',
+  textColorSecondary: '#000000',
+  textColorTertiary: '#000000',
+  schemeColorLightest: '#D2F9FA'
+}
+
+export default [
+  YELLOW,
+  PINK,
+  BLUE,
+  GREEN,
+  AQUA
+]

--- a/src/utils/colorSchemes.js
+++ b/src/utils/colorSchemes.js
@@ -4,6 +4,7 @@ export const YELLOW = {
   borderColor: '#CC9800',
   textColorPrimary: '#000000',
   schemeColorLighter: '#FFCB32',
+  hoverColorLighter: '#FFC519',
   textColorSecondary: '#000000',
   textColorTertiary: '#000000',
   schemeColorLightest: '#FFF2CC'

--- a/src/utils/colorSchemes.js
+++ b/src/utils/colorSchemes.js
@@ -58,10 +58,12 @@ export const AQUA = {
   schemeColorLightest: '#D2F9FA'
 }
 
-export default [
+const colorSchemes = [
   YELLOW,
   PINK,
   BLUE,
   GREEN,
   AQUA
 ]
+
+export default colorSchemes

--- a/yarn.lock
+++ b/yarn.lock
@@ -11903,6 +11903,11 @@ react-sizeme@^3.0.1:
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
 
+react-slide-toggle@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/react-slide-toggle/-/react-slide-toggle-0.3.5.tgz#7fd3a6847ca10eb986af29d54eb02a870202be82"
+  integrity sha512-dV2PkLGiE7m66Ohk36jLqaaneUYc0ZpQe/ZmYEU3+7TVXfZwddimFyjeDfVzPhlqDcpK1yfKJ8NN7aIyR9bOTA==
+
 react-syntax-highlighter@^13.5.3:
   version "13.5.3"
   resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-13.5.3.tgz#9712850f883a3e19eb858cf93fad7bb357eea9c6"


### PR DESCRIPTION
## Context

[**Create Shopping List component**](https://trello.com/c/TXTbY8wN/7-create-shopping-list-component)
[**Deal with prop-types**](https://trello.com/c/GeXOcWwt/13-deal-with-prop-types)
[**Implement Loading component**](https://trello.com/c/pLIL6EQz/14-implement-loading-component)

Although the API offers functionality to view or manage shopping lists, the front end does not yet support this feature. We need a shopping list page on the dashboard where users can view their shopping lists. (Creating or removing shopping lists and updating items on lists are out of scope for this work.) Users need to be able to see what shopping lists they have and what list items are on each list.

There were a couple additional issues that needed to be addressed:

* Components with props don't have prop-types set, or didn't have them set properly to describe the shape of objects passed in as props
* Components fetching data from the API don't adequately handle loading states or error responses from the API
* CSS issues persist - in particular, the `DashboardHeader` component continues to cut off the profile image at narrower screen widths

This epic PR addresses all of these.

## Changes

* Create `ShoppingListItem` component with stories
* Create `ShoppingList` component with stories
* Create `Loading` component with stories
* Add correct prop-types to all components requiring props
* Improve handling of loading and error states to components making API calls
* Fix CSS for `DashboardHeader` component so that profile image is visible even at smaller widths
* Add `colorSchemes` module that exports `YELLOW`, `PINK`, `BLUE`, `GREEN`, and `AQUA` colour schemes (as well as a default export that is an array of all schemes)
