### PR TITLE
Remove cookies as dependency of useEffect hook that changes them

### DIFF
--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -72,7 +72,7 @@ const DashboardHeader = () => {
     }
   }
 
-  useEffect(fetchUserData, [cookies, removeCookie])
+  useEffect(fetchUserData, [removeCookie])
 
   return(!!shouldRedirect ?
     <Redirect to={paths.login} /> :

--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -72,7 +72,7 @@ const DashboardHeader = () => {
     }
   }
 
-  useEffect(fetchUserData, [])
+  useEffect(fetchUserData, [removeCookie])
 
   return(!!shouldRedirect ?
     <Redirect to={paths.login} /> :

--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -72,7 +72,7 @@ const DashboardHeader = () => {
     }
   }
 
-  useEffect(fetchUserData, [removeCookie])
+  useEffect(fetchUserData, [])
 
   return(!!shouldRedirect ?
     <Redirect to={paths.login} /> :


### PR DESCRIPTION
## Context

[**Prevent chain of requests to backend when data fetch fails**](https://trello.com/c/VBO6you3/15-prevent-chain-of-requests-to-backend-when-data-fetch-fails)

The `useEffect` hook that fetches user profile data from the backend in the `DashboardHeader` component includes `cookies` in its dependency array. However, `cookies` are changed inside the hook if a 401 response is returned. This results in the hook running again and again when the 401 response is returned in an endless loop.

## Change

* Remove `cookies` from the dependency array of the `useEffect` hook in the `DashboardHeader` component
* Remove `removeCookie` from the dependency array because this is a function and doesn't change so I don't think including it actually does anything

## Considerations

Really the user should be logged out on any 401 response from the API,  since that response is caused by their token being invalidated or revoked on the Google side. However, fixing this more broadly was out of scope for this bug fix.