### PR TITLE
Fix issue where user not redirected on logout

### DIFF
--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { useCookies } from 'react-cookie'
-import { Link, Redirect  } from 'react-router-dom'
+import { Link, Redirect } from 'react-router-dom'
 import paths from '../../routing/paths'
 import { sessionCookieName, backendBaseUri } from '../../utils/config'
 import isStorybook from '../../utils/isStorybook'


### PR DESCRIPTION
## Context

[**User not redirected after logout**](https://trello.com/c/iTnwxjsL/26-user-not-redirected-after-logout)
[**Redirect to the homepage and not the login page after logout**](https://trello.com/c/BeHi0nAO/11-redirect-to-the-homepage-and-not-the-login-page-after-logout)

There was an issue, present in production and able to be reproduced in dev, where, when a user clicked the logout button, nothing appeared to happen. The logout button was not hidden nor was the user redirected. (The cookie was removed and the user would be taken to the login screen next time they reloaded the page or navigated.) Users should know when their logout was successful or not.

In the process of fixing this bug, I also fixed the bug for the second linked card - the one where users were previously being directed to the login page and not the homepage on logout.

## Changes

* Change `shouldRedirect` and `setShouldRedirect` to `shouldRedirectTo` and `setShouldRedirectTo` where you can set the value of the path the user should see
* Use `setShouldRedirectTo` in logout callback instead of returning a `Redirect` object (which clearly wasn't working)