### PR TITLE
Create ColorContext

### DIFF
--- a/src/components/navigationCard/navigationCard.js
+++ b/src/components/navigationCard/navigationCard.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
+import useColorScheme from '../../hooks/useColorScheme'
 import styles from './navigationCard.module.css'
 
-const NavigationCard = ({ colorScheme, href, children }) => {
+const NavigationCard = ({ href, children }) => {
+  const [{ schemeColor, hoverColor, textColorPrimary}] = useColorScheme()
+
   const styleVars = {
-    '--background-color': colorScheme.schemeColor,
-    '--hover-color': colorScheme.hoverColor,
-    '--text-color': colorScheme.textColorPrimary
+    '--background-color': schemeColor,
+    '--hover-color': hoverColor,
+    '--text-color': textColorPrimary
   }
 
   return(
@@ -18,17 +21,6 @@ const NavigationCard = ({ colorScheme, href, children }) => {
 }
 
 NavigationCard.propTypes = {
-  colorScheme: PropTypes.shape({
-    schemeColor: PropTypes.string.isRequired,
-    hoverColor: PropTypes.string.isRequired,
-    textColorPrimary: PropTypes.string.isRequired,
-    borderColor: PropTypes.string,
-    schemeColorLighter: PropTypes.string,
-    hoverColorLighter: PropTypes.string,
-    schemeColorLightest: PropTypes.string,
-    textColorSecondary: PropTypes.string,
-    textColorTertiary: PropTypes.string
-  }).isRequired,
   href: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired
 }

--- a/src/components/navigationCard/navigationCard.stories.js
+++ b/src/components/navigationCard/navigationCard.stories.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import { GREEN } from '../../utils/colorSchemes'
+import { ColorProvider } from '../../contexts/colorContext'
 import NavigationCard from './navigationCard'
 
 export default { title: 'NavigationCard' }
 
 export const Default = () => (
-  <NavigationCard colorScheme={GREEN} href='#'>
-    Your Shopping List
-  </NavigationCard>
+  <ColorProvider colorScheme={GREEN}>
+    <NavigationCard colorScheme={GREEN} href='#'>
+      Your Shopping List
+    </NavigationCard>
+  </ColorProvider>
 )

--- a/src/components/navigationMosaic/navigationMosaic.js
+++ b/src/components/navigationMosaic/navigationMosaic.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { ColorProvider } from '../../contexts/colorContext'
 import NavigationCard from '../navigationCard/navigationCard'
 import styles from './navigationMosaic.module.css'
 
@@ -7,11 +8,12 @@ const NavigationMosaic = ({ cardArray }) => (
   <div className={styles.root}>
     {cardArray.map(({ colorScheme, href, children, key }) => (
       <div key={key} className={styles.card}>
-        <NavigationCard 
-          colorScheme={colorScheme}
-          href={href}
-          children={children}
-        />
+        <ColorProvider colorScheme={colorScheme}>
+          <NavigationCard 
+            href={href}
+            children={children}
+          />
+        </ColorProvider>
       </div>
     ))}
   </div>

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react'
 import useComponentVisible from '../../hooks/useComponentVisible'
+import useColorScheme from '../../hooks/useColorScheme'
 import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
@@ -18,7 +19,13 @@ const isValid = str => (
   !!str && str.match(/^\s*[a-z0-9 ]*\s*$/i)[0] === str
 )
 
-const ShoppingList = ({ canEdit = true, title, onSubmitEditForm, colorScheme, listItems = [] }) => {
+const ShoppingList = ({ canEdit = true, title, onSubmitEditForm, listItems = [] }) => {
+  const [toggleEvent, setToggleEvent] = useState(0)
+  const [currentTitle, setCurrentTitle] = useState(title)
+  const [colorScheme] = useColorScheme()
+  const slideTriggerRef = useRef(null)
+  const { componentRef, triggerRef, isComponentVisible, setIsComponentVisible } = useComponentVisible()
+
   const {
     schemeColor,
     hoverColor,
@@ -39,11 +46,6 @@ const ShoppingList = ({ canEdit = true, title, onSubmitEditForm, colorScheme, li
     bodyBackgroundColor: schemeColorLightest,
     bodyTextColor: textColorTertiary
   }
-
-  const [toggleEvent, setToggleEvent] = useState(0)
-  const [currentTitle, setCurrentTitle] = useState(title)
-  const slideTriggerRef = useRef(null)
-  const { componentRef, triggerRef, isComponentVisible, setIsComponentVisible } = useComponentVisible()
 
   const slideTriggerRefContains = element => slideTriggerRef.current && (slideTriggerRef.current === element || slideTriggerRef.current.contains(element))
   const triggerRefContains = element => triggerRef.current && (triggerRef.current === element || triggerRef.current.contains(element))
@@ -118,17 +120,6 @@ const ShoppingList = ({ canEdit = true, title, onSubmitEditForm, colorScheme, li
 ShoppingList.propTypes = {
   title: PropTypes.string.isRequired,
   canEdit: PropTypes.bool,
-  colorScheme: PropTypes.shape({
-    schemeColor: PropTypes.string.isRequired,
-    hoverColor: PropTypes.string.isRequired,
-    borderColor: PropTypes.string.isRequired,
-    textColorPrimary: PropTypes.string.isRequired,
-    schemeColorLighter: PropTypes.string.isRequired,
-    hoverColorLighter: PropTypes.string.isRequired,
-    schemeColorLightest: PropTypes.string.isRequired,
-    textColorSecondary: PropTypes.string.isRequired,
-    textColorTertiary: PropTypes.string.isRequired
-  }).isRequired,
   onSubmitEditForm: PropTypes.func.isRequired,
   listItems: PropTypes.arrayOf(PropTypes.shape).isRequired
 }

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -1,7 +1,8 @@
 import React, { useState, useRef } from 'react'
 import useComponentVisible from '../../hooks/useComponentVisible'
-import useColorScheme from '../../hooks/useColorScheme'
 import PropTypes from 'prop-types'
+import useColorScheme from '../../hooks/useColorScheme'
+import { ColorProvider } from '../../contexts/colorContext'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
 import SlideToggle from 'react-slide-toggle'
@@ -84,13 +85,15 @@ const ShoppingList = ({ canEdit = true, title, onSubmitEditForm, listItems = [] 
             <FontAwesomeIcon className={styles.fa} icon={faEdit} />
           </div>}
           {canEdit && isComponentVisible ?
-            <ShoppingListForm
-              formRef={componentRef}
-              className={styles.form}
-              colorScheme={colorScheme}
-              title={title}
-              onSubmit={submitAndHideForm}
-            /> :
+            <ColorProvider colorScheme={colorScheme}>
+              <ShoppingListForm
+                formRef={componentRef}
+                className={styles.form}
+                colorScheme={colorScheme}
+                title={title}
+                onSubmit={submitAndHideForm}
+              />
+            </ColorProvider> :
             <h3 className={styles.title}>{currentTitle}</h3>}
         </div>
       </div>

--- a/src/components/shoppingList/shoppingList.stories.js
+++ b/src/components/shoppingList/shoppingList.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { PINK } from '../../utils/colorSchemes'
+import { ColorProvider } from '../../contexts/colorContext'
 import ShoppingList from './shoppingList'
 
 const listItems = [
@@ -29,20 +30,24 @@ const listItems = [
 export default { title: 'ShoppingList' }
 
 export const Default = () => (
-  <ShoppingList
-    title='My List 1'
-    onSubmitEditForm={e => e.preventDefault()}
-    colorScheme={PINK}
-    listItems={listItems}
-  />
+  <ColorProvider colorScheme={PINK}>
+    <ShoppingList
+      title='My List 1'
+      onSubmitEditForm={e => e.preventDefault()}
+      colorScheme={PINK}
+      listItems={listItems}
+    />
+  </ColorProvider>
 )
 
 export const NotEditable = () => (
-  <ShoppingList
-    title='Master'
-    canEdit={false}
-    onSubmitEditForm={e => e.preventDefault()}
-    colorScheme={PINK}
-    listItems={listItems}
-  />
+  <ColorProvider colorScheme={PINK}>
+    <ShoppingList
+      title='Master'
+      canEdit={false}
+      onSubmitEditForm={e => e.preventDefault()}
+      colorScheme={PINK}
+      listItems={listItems}
+    />
+  </ColorProvider>
 )

--- a/src/components/shoppingListForm/shoppingListForm.js
+++ b/src/components/shoppingListForm/shoppingListForm.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
+import useColorScheme from '../../hooks/useColorScheme'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheckSquare } from '@fortawesome/free-regular-svg-icons'
 import styles from './shoppingListForm.module.css'
 
-const ShoppingListForm = ({ formRef, className, colorScheme, title, onSubmit }) => {
+const ShoppingListForm = ({ formRef, className, title, onSubmit }) => {
   const getInputTextWidth = (text) => {
     const canvas = document.createElement('canvas')
     const context = canvas.getContext('2d')
@@ -17,6 +18,8 @@ const ShoppingListForm = ({ formRef, className, colorScheme, title, onSubmit }) 
   const [inputValue, setInputValue] = useState(title)
   const [inputWidth, setInputWidth] = useState(`${getInputTextWidth(title)}px`)
   const inputRef = useRef(null)
+
+  const [ colorScheme ] = useColorScheme()
 
   const { schemeColor, textColorPrimary, borderColor, schemeColorLightest } = colorScheme
 
@@ -61,17 +64,6 @@ ShoppingListForm.propTypes = {
     current: PropTypes.instanceOf(Element)
   }),
   className: PropTypes.string.isRequired,
-  colorScheme: PropTypes.shape({
-    schemeColor: PropTypes.string.isRequired,
-    borderColor: PropTypes.string.isRequired,
-    textColorPrimary: PropTypes.string.isRequired,
-    schemeColorLightest: PropTypes.string.isRequired,
-    hoverColor: PropTypes.string,
-    schemeColorLighter: PropTypes.string,
-    hoverColorLighter: PropTypes.string,
-    textColorSecondary: PropTypes.string,
-    textColorTertiary: PropTypes.string
-  }).isRequired,
   onSubmit: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired
 }

--- a/src/components/shoppingListForm/shoppingListForm.stories.js
+++ b/src/components/shoppingListForm/shoppingListForm.stories.js
@@ -1,14 +1,16 @@
 import React from 'react'
 import { PINK } from '../../utils/colorSchemes'
+import { ColorProvider } from '../../contexts/colorContext'
 import ShoppingListForm from './shoppingListForm'
 
 export default { title: 'ShoppingListForm' }
 
 export const Default = () => (
-  <ShoppingListForm
-    className='foo'
-    colorScheme={PINK}
-    title='Severin Manor'
-    onSubmit={e => e.preventDefault()}
-  />
+  <ColorProvider colorScheme={PINK}>
+    <ShoppingListForm
+      className='foo'
+      title='Severin Manor'
+      onSubmit={e => e.preventDefault()}
+    />
+  </ColorProvider>
 )

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -1,14 +1,17 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import useColorScheme from '../../hooks/useColorScheme'
 import SlideToggle from 'react-slide-toggle'
 import styles from './shoppingListItem.module.css'
 
 const ShoppingListItem = ({
   description,
   quantity,
-  notes,
-  colorScheme
+  notes
 }) => {
+  const [colorScheme] = useColorScheme()
+  const [toggleEvent, setToggleEvent] = useState(0)
+
   const {
     schemeColor,
     hoverColor,
@@ -17,9 +20,7 @@ const ShoppingListItem = ({
     bodyBackgroundColor,
     bodyTextColor
   } = colorScheme
-
-  const [toggleEvent, setToggleEvent] = useState(0)
-
+  
   const toggleDetails = () => {
     setToggleEvent(Date.now)
   }
@@ -55,14 +56,6 @@ const ShoppingListItem = ({
 }
 
 ShoppingListItem.propTypes = {
-  colorScheme: PropTypes.shape({
-    schemeColor: PropTypes.string.isRequired,
-    hoverColor: PropTypes.string.isRequired,
-    titleTextColor: PropTypes.string.isRequired,
-    borderColor: PropTypes.string.isRequired,
-    bodyBackgroundColor: PropTypes.string.isRequired,
-    bodyTextColor: PropTypes.string.isRequired
-  }).isRequired,
   description: PropTypes.string.isRequired,
   quantity: PropTypes.number.isRequired,
   notes: PropTypes.string

--- a/src/components/shoppingListItem/shoppingListItem.stories.js
+++ b/src/components/shoppingListItem/shoppingListItem.stories.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ColorProvider } from '../../contexts/colorContext'
 import ShoppingListItem from './shoppingListItem'
 
 const colorScheme = {
@@ -13,10 +14,12 @@ const colorScheme = {
 export default { title: 'ShoppingListItem' }
 
 export const Default = () => (
-  <ShoppingListItem
-    description='Ebony sword'
-    quantity={2}
-    notes='One to enchant with Soul Trap, one to enchant with Absorb Health'
-    colorScheme={colorScheme}
-  />
+  <ColorProvider colorScheme={colorScheme}>
+    <ShoppingListItem
+      description='Ebony sword'
+      quantity={2}
+      notes='One to enchant with Soul Trap, one to enchant with Absorb Health'
+      colorScheme={colorScheme}
+    />
+  </ColorProvider>
 )

--- a/src/contexts/colorContext.js
+++ b/src/contexts/colorContext.js
@@ -1,0 +1,33 @@
+import { createContext, useState, useMemo } from 'react'
+import PropTypes from 'prop-types'
+
+
+const ColorContext = createContext()
+
+const ColorProvider = ({ colorScheme, children }) => {
+  const [scheme, setScheme] = useState(colorScheme)
+  const value = useMemo(() => [scheme, setScheme], [scheme])
+
+  return(
+    <ColorContext.Provider value={value} colorScheme={scheme}>
+      {children}
+    </ColorContext.Provider>
+  )
+}
+
+ColorProvider.propTypes = {
+  colorScheme: PropTypes.shape({
+    schemeColor: PropTypes.string.isRequired,
+    hoverColor: PropTypes.string.isRequired,
+    textColorPrimary: PropTypes.string.isRequired,
+    borderColor: PropTypes.string,
+    schemeColorLighter: PropTypes.string,
+    hoverColorLighter: PropTypes.string,
+    schemeColorLightest: PropTypes.string,
+    textColorSecondary: PropTypes.string,
+    textColorTertiary: PropTypes.string
+  }).isRequired,
+  children: PropTypes.node.isRequired
+}
+
+export { ColorProvider, ColorContext }

--- a/src/hooks/useColorScheme.js
+++ b/src/hooks/useColorScheme.js
@@ -1,0 +1,14 @@
+import { useContext } from 'react'
+import { ColorContext } from '../contexts/colorContext'
+
+const useColorScheme = () => {
+  const context = useContext(ColorContext)
+
+  if (!context) { 
+    throw new Error('useColorScheme must be used within a ColorProvider')
+  }
+
+  return context
+}
+
+export default useColorScheme

--- a/src/pages/shoppingListPage/shoppingListPage.js
+++ b/src/pages/shoppingListPage/shoppingListPage.js
@@ -3,6 +3,7 @@ import { useCookies } from 'react-cookie'
 import { backendBaseUri, sessionCookieName } from '../../utils/config'
 import colorSchemes, { YELLOW } from '../../utils/colorSchemes'
 import isStorybook from '../../utils/isStorybook'
+import { ColorProvider } from '../../contexts/colorContext'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
 import ShoppingList from '../../components/shoppingList/shoppingList'
@@ -122,15 +123,17 @@ const ShoppingListPage = () => {
           const listKey = title.toLowerCase().replace(' ', '-')
 
           return(
-            <div className={styles.shoppingList} key={listKey}>
-              <ShoppingList
-                canEdit={!master}
-                title={title}
-                listItems={shopping_list_items}
-                colorScheme={colorSchemes[colorSchemesIndex]}
-                onSubmitEditForm={(e) => updateList(id, e)}
-              />
-            </div>
+            <ColorProvider key={listKey} colorScheme={colorSchemes[colorSchemesIndex]}>
+              <div className={styles.shoppingList}>
+                  <ShoppingList
+                    canEdit={!master}
+                    title={title}
+                    listItems={shopping_list_items}
+                    colorScheme={colorSchemes[colorSchemesIndex]}
+                    onSubmitEditForm={(e) => updateList(id, e)}
+                  />
+              </div>
+            </ColorProvider>
           )
         }) : <p className={styles.noLists}>You have no shopping lists.</p>) :
         loadingState === LOADING ?


### PR DESCRIPTION
## Context

[**Create ColorContext**](https://trello.com/c/zx23NoKX/23-create-colorcontext)

There are a number of components now that use colour schemes and there was some prop drilling going on where components passed colour schemes through to their children. We wanted to not use so much prop drilling. React contexts are a perfect solution for this that prevents the need to use Redux or a similar tool and is native to React.

There's an [additional motive](https://trello.com/c/hy8NBB76/24-investigate-creating-a-dashboardcontext) for using React contexts for this: we're going to be investigating the use of a `DashboardContext` that keeps track of the data - including auth data - to be used for dashboard pages.

## Changes

* Create `ColorContext` and `ColorProvider` to keep track of colour schemes
* Change existing components to use the `ColorContext` instead of passing in colour schemes as props
* Update Storybook to wrap components in a provider (required for the context to work)
