### PR TITLE
Fix colour bug in shopping list item

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Summary of the changes made, preferably as a bulleted list
 
 ## Considerations
 
-Explanation of design/implementation decisions or which alternatives you considereed or tried
+Explanation of design/implementation decisions or which alternatives you considered or tried
 
 ## Manual Test Cases
 

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -13,12 +13,12 @@ const ShoppingListItem = ({
   const [toggleEvent, setToggleEvent] = useState(0)
 
   const {
-    schemeColor,
-    hoverColor,
-    titleTextColor,
+    schemeColorLighter,
+    hoverColorLighter,
+    textColorSecondary,
     borderColor,
-    bodyBackgroundColor,
-    bodyTextColor
+    schemeColorLightest,
+    textColorTertiary
   } = colorScheme
   
   const toggleDetails = () => {
@@ -26,12 +26,12 @@ const ShoppingListItem = ({
   }
 
   const styleVars = {
-    '--scheme-color': schemeColor,
-    '--title-text-color': titleTextColor,
+    '--main-color': schemeColorLighter,
+    '--title-text-color': textColorSecondary,
     '--border-color': borderColor,
-    '--body-background-color': bodyBackgroundColor,
-    '--body-text-color': bodyTextColor,
-    '--hover-color': hoverColor
+    '--body-background-color': schemeColorLightest,
+    '--body-text-color': textColorTertiary,
+    '--hover-color': hoverColorLighter
   }
 
   return(

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -1,6 +1,6 @@
 .root {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
-  background-color: var(--scheme-color);
+  background-color: var(--main-color);
   border-bottom: 1px solid var(--border-color);
 }
 


### PR DESCRIPTION
## Context

I noticed that there was a little bug where the shopping list items were using the main scheme colours instead of the lighter colours, making them the same colour as the parent element. This PR fixes the colours in the list items.

## Changes

* Use correct colours for the `ShoppingListItem` component

## Screenshots and GIFs

<img width="1680" alt="Screen Shot 2021-06-27 at 7 58 46 pm" src="https://user-images.githubusercontent.com/5115928/123540449-5cf1c180-d782-11eb-857c-7ffaa4685532.png">
