### PR TITLE
Show loading component while profile data loads in dashboard

### DIFF
--- a/src/contexts/dashboardContext.js
+++ b/src/contexts/dashboardContext.js
@@ -6,6 +6,9 @@ import { backendBaseUri, sessionCookieName } from '../utils/config'
 import isStorybook from '../utils/isStorybook'
 import paths from '../routing/paths'
 
+const LOADING = 'loading'
+const DONE = 'done'
+
 const DashboardContext = createContext()
 
 // overrideValue allows us to set the context value in Storybook.
@@ -17,6 +20,7 @@ const DashboardProvider = ({ children, overrideValue = {} }) => {
   const [cookies, setCookie, removeCookie] = useCookies([sessionCookieName])
   const [profileData, setProfileData] = useState(null)
   const [shouldRedirect, setShouldRedirect] = useState(false)
+  const [profileLoadState, setProfileLoadState] = useState(LOADING)
 
   const setSessionCookie = val => setCookie(sessionCookieName, val)
   const removeSessionCookie = () => removeCookie(sessionCookieName)
@@ -27,6 +31,7 @@ const DashboardProvider = ({ children, overrideValue = {} }) => {
     setSessionCookie,
     removeSessionCookie,
     setProfileData,
+    profileLoadState,
     ...overrideValue // enables you to only change certain values
   }
 
@@ -53,6 +58,7 @@ const DashboardProvider = ({ children, overrideValue = {} }) => {
           setShouldRedirect(true)
         } else {
           setProfileData(data)
+          if (!overrideValue.profileLoadState) setProfileLoadState(DONE)
         }
       })
       .catch(error => {
@@ -62,7 +68,7 @@ const DashboardProvider = ({ children, overrideValue = {} }) => {
       })
     } else if (!cookies[sessionCookieName] && !isStorybook()) {
       setShouldRedirect(true)
-    }
+    } else if (isStorybook() && !overrideValue.profileLoadState) setProfileLoadState(DONE) 
   }
 
   useEffect(fetchProfileData, [])

--- a/src/pages/dashboardPage/dashboardPage.js
+++ b/src/pages/dashboardPage/dashboardPage.js
@@ -10,6 +10,7 @@ import {
 import paths from '../../routing/paths'
 import { useDashboardContext } from '../../hooks/contexts'
 import DashboardLayout from '../../layouts/dashboardLayout'
+import Loading from '../../components/loading/loading'
 import NavigationMosaic from '../../components/navigationMosaic/navigationMosaic'
 import styles from './dashboardPage.module.css'
 
@@ -47,13 +48,14 @@ const cards = [
 ]
 
 const DashboardPage = () => {
-  const { token } = useDashboardContext()
+  const { token, profileLoadState } = useDashboardContext()
   
   return(token ?
     <DashboardLayout>
-      <div className={styles.root}>
+      {profileLoadState === 'done' ? <div className={styles.root}>
         <NavigationMosaic cardArray={cards} />
-      </div>
+      </div> :
+      <Loading className={styles.loading} type='bubbles' color={YELLOW.schemeColor} height='15%' width='15%' />}
     </DashboardLayout> :
     <Redirect to={paths.login} />
   )

--- a/src/pages/dashboardPage/dashboardPage.module.css
+++ b/src/pages/dashboardPage/dashboardPage.module.css
@@ -2,3 +2,7 @@
   background-color: #f0f0f0;
   padding-top: 132px;
 }
+
+.loading {
+  margin: 0 auto;
+}

--- a/src/pages/dashboardPage/dashboardPage.stories.js
+++ b/src/pages/dashboardPage/dashboardPage.stories.js
@@ -17,3 +17,9 @@ export const Default = () => (
     <DashboardPage />
   </DashboardProvider>
 )
+
+export const Loading = () => (
+  <DashboardProvider overrideValue={{ token: 'xxxxxx', profileLoadState: 'loading' }}>
+    <DashboardPage />
+  </DashboardProvider>
+)


### PR DESCRIPTION
## Context

There was a little issue in prod where, while waiting for the profile data to load, weird stuff was happening. This hopefully fixes that.

## Changes

* Show loading component while profile data loads in dashboard

## Considerations

I haven't tested this locally because there isn't enough latency on my local machine to make it work. That's why this bug was only discovered in prod. I'm kind of shooting from the hip here but whether it fixes the bug or not it'll be a good feature.

## Manual Test Cases

Steps to reproduce:

1. Log into SIM in prod and go to the dashboard
2. Manually remove your `_sim_google_session` cookie
3. Reload the page

Second test case:

1. Log into SIM in prod and go to the shopping list page
2. Manually remove your `_sim_google_session` cookie
3. Reload the page

In both these cases, you should see the dashboard display for a second or a few seconds while it makes the API call before it redirects to the login page.
