### PR TITLE
Enable user to remove shopping lists from the UI

### DIFF
--- a/.storybook/mocks/handlers.js
+++ b/.storybook/mocks/handlers.js
@@ -4,4 +4,5 @@ export const handlers = [
   rest.get('/users/current', null),
   rest.post('/shopping_lists', null),
   rest.patch('/shopping_lists/:id', null),
+  rest.delete('/shopping_lists/:id', null)
 ]

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -224,6 +224,8 @@ On load, the `ShoppingListProvider` fetches all the user's shopping lists. It re
   * `error`: an optional error callback that can be used to clean up state within the component that calls the function
 * `flashProps`: the props to be passed to the `FlashMessage` component when/if it is displayed
 * `flashVisible`: whether a `FlashMessage` should be visible (set to `true` if there's been some kind of error)
+* `setFlashProps`: a function to set the type and message in the `FlashMessage` component; takes an object argument
+* `setFlashVisible`: a function to set the visibility of the `FlashMessage` component; takes a boolean argument
 
 ### Testing
 

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -210,16 +210,20 @@ On load, the `ShoppingListProvider` fetches all the user's shopping lists. It re
 * `shoppingLists`: the array of all the user's shopping lists, with the master list first
 * `shoppingListLoadingState`: whether the `shoppingLists` are 'loading' (waiting for the API call to resolve), 'done' (when the API call is finished), or 'error' (when the API call has thrown an honest-to-god, unexpected error - not just when it returns a 400-range error code)
 * `performShoppingListUpdate`: a function that updates the list specified through the API, also encompassing error handling logic. The function takes 4 arguments:
-  * `listId`: The ID (primary key in the database) of the list to be updated
-  * `newTitle`: The new title of the list taken from the form the user submitted
-  * `success`: An optional success callback that can be used for handling state within the component that calls the function
-  * `error`: An optional error callback that can be used to clean up state within the component that calls the function
-* `performShoppingListCreate`: a function that creates a shopping list for the authenticated user, also encompassing error handling logic. The function takes three arguments:
-  * `title`: The title of the new list
-  * `success`: An optional success callback that can be used for handling state within the component that calls the function
-  * `error`: An optional error callback that can be used to clean up state within the component that calls the function
-* `flashProps`: The props to be passed to the `FlashMessage` component when/if it is displayed
-* `flashVisible`: Whether a `FlashMessage` should be visible (set to `true` if there's been some kind of error)
+  * `listId`: the ID (primary key in the database) of the list to be updated
+  * `newTitle`: the new title of the list taken from the form the user submitted
+  * `success`: an optional success callback that can be used for handling state within the component that calls the function
+  * `error`: an optional error callback that can be used to clean up state within the component that calls the function
+* `performShoppingListCreate`: a function that creates a shopping list for the authenticated user, also encompassing error handling logic. The function takes 3 arguments:
+  * `title`: the title of the new list
+  * `success`: an optional success callback that can be used for handling state within the component that calls the function
+  * `error`: an optional error callback that can be used to clean up state within the component that calls the function
+* `performShoppingListDelete`: a function that deletes the list specified through the API, also encompassing error handling logic. The function takes 3 arguments:
+  * `listId`: the ID (primary key in the database) of the list to be updated
+  * `success`: an optional success callback that can be used for handling state within the component that calls the function
+  * `error`: an optional error callback that can be used to clean up state within the component that calls the function
+* `flashProps`: the props to be passed to the `FlashMessage` component when/if it is displayed
+* `flashVisible`: whether a `FlashMessage` should be visible (set to `true` if there's been some kind of error)
 
 ### Testing
 

--- a/src/components/flashMessage/flashMessage.js
+++ b/src/components/flashMessage/flashMessage.js
@@ -16,7 +16,7 @@ const colors = {
   [INFO]: {
     body: '#cce5ff',
     border: '#b3d8ff',
-    text: '#6289b2',
+    text: '#4e6d8e',
   },
   [ERROR]: {
     body: '#ffcccc',

--- a/src/components/navigationMosaic/navigationMosaic.stories.js
+++ b/src/components/navigationMosaic/navigationMosaic.stories.js
@@ -12,14 +12,14 @@ const cards = [
   {
     colorScheme: YELLOW,
     href: '#',
-    children: 'Your Shopping Lists',
-    key: 'card-1'
+    children: 'Your Games',
+    key: 'your-games'
   },
   {
     colorScheme: PINK,
     href: '#',
-    children: 'Nav Link 2',
-    key: 'card-2'
+    children: 'Your Shopping Lists',
+    key: 'your-shopping-lists'
   },
   {
     colorScheme: BLUE,

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -26,7 +26,6 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
   const [listItems, setListItems] = useState(null)
   const slideTriggerRef = useRef(null)
   const deleteTriggerRef = useRef(null)
-  const mountedRef = useRef(true)
   const { componentRef, triggerRef, isComponentVisible, setIsComponentVisible } = useComponentVisible()
 
   const {
@@ -86,7 +85,7 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
     const confirmed = window.confirm(`Are you sure you want to delete the list "${title}"? You will also lose any list items on the list. This action cannot be undone.`)
 
     if (confirmed) {
-      performShoppingListDelete(listId, () => { mountedRef.current = false })
+      performShoppingListDelete(listId)
     } else {
       setFlashProps({
         type: 'info',
@@ -102,10 +101,6 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
     const items = shoppingLists.find(obj => obj.id === listId).shopping_list_items
     setListItems(items)
   }, [shoppingLists])
-
-  useEffect(() => (
-    () => (mountedRef.current = false)
-  ))
 
   return(
     <div className={styles.root} style={styleVars}>

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { useColorScheme, useShoppingListContext } from '../../hooks/contexts'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import SlideToggle from 'react-slide-toggle'
 import ShoppingListEditForm from '../shoppingListEditForm/shoppingListEditForm'
 import ShoppingListItem from '../shoppingListItem/shoppingListItem'
@@ -24,15 +25,18 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
   const [currentTitle, setCurrentTitle] = useState(title)
   const [listItems, setListItems] = useState(null)
   const slideTriggerRef = useRef(null)
+  const deleteTriggerRef = useRef(null)
+  const mountedRef = useRef(true)
   const { componentRef, triggerRef, isComponentVisible, setIsComponentVisible } = useComponentVisible()
-  const { shoppingLists, performShoppingListUpdate } = useShoppingListContext()
+  const { shoppingLists, performShoppingListUpdate, performShoppingListDelete } = useShoppingListContext()
 
   const originalTitle = title // to switch back in case of API error
 
   const slideTriggerRefContains = element => slideTriggerRef.current && (slideTriggerRef.current === element || slideTriggerRef.current.contains(element))
   const triggerRefContains = element => triggerRef.current && (triggerRef.current === element || triggerRef.current.contains(element))
+  const deleteTriggerRefContains = element => deleteTriggerRef.current && (deleteTriggerRef.current === element || deleteTriggerRef.current.contains(element))
   const componentRefContains = element => componentRef.current && (componentRef.current === element || componentRef.current.contains(element))
-  const shouldToggleListItems = element => (slideTriggerRefContains(element) && !triggerRefContains(element)) && !componentRefContains(element)
+  const shouldToggleListItems = element => (slideTriggerRefContains(element) && !triggerRefContains(element)) && !componentRefContains(element) && !deleteTriggerRefContains(element)
 
   const toggleListItems = (e) => {
     if (shouldToggleListItems(e.target)) {
@@ -69,6 +73,12 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
     setIsComponentVisible(false)
   }
 
+  const deleteList = e => {
+    e.preventDefault()
+
+    performShoppingListDelete(listId, () => { mountedRef.current = false })
+  }
+
   useEffect(() => {
     if (shoppingLists === undefined) return // it'll run again when they populate
 
@@ -76,13 +86,23 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
     setListItems(items)
   }, [shoppingLists])
 
+  useEffect(() => (
+    () => (mountedRef.current = false)
+  ))
+
   return(
     <div className={styles.root} style={styleVars}>
       <div className={styles.titleContainer}>
         <div className={styles.trigger} ref={slideTriggerRef} onClick={toggleListItems}>
-          {canEdit && <div ref={triggerRef}>
-            <FontAwesomeIcon className={styles.fa} icon={faEdit} />
-          </div>}
+          {canEdit &&
+          <>
+            <div className={styles.icon} ref={deleteTriggerRef} onClick={deleteList}>
+              <FontAwesomeIcon className={styles.fa} icon={faTimes} />
+            </div>
+            <div className={styles.icon} ref={triggerRef}>
+              <FontAwesomeIcon className={styles.fa} icon={faEdit} />
+            </div>
+          </>}
           {canEdit && isComponentVisible ?
             <ShoppingListEditForm
               formRef={componentRef}

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -28,7 +28,14 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
   const deleteTriggerRef = useRef(null)
   const mountedRef = useRef(true)
   const { componentRef, triggerRef, isComponentVisible, setIsComponentVisible } = useComponentVisible()
-  const { shoppingLists, performShoppingListUpdate, performShoppingListDelete } = useShoppingListContext()
+
+  const {
+    shoppingLists,
+    performShoppingListUpdate,
+    performShoppingListDelete,
+    setFlashProps,
+    setFlashVisible
+  } = useShoppingListContext()
 
   const originalTitle = title // to switch back in case of API error
 
@@ -76,7 +83,17 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
   const deleteList = e => {
     e.preventDefault()
 
-    performShoppingListDelete(listId, () => { mountedRef.current = false })
+    const confirmed = window.confirm(`Are you sure you want to delete the list "${title}"? You will also lose any list items on the list. This action cannot be undone.`)
+
+    if (confirmed) {
+      performShoppingListDelete(listId, () => { mountedRef.current = false })
+    } else {
+      setFlashProps({
+        type: 'info',
+        message: 'Your list was not deleted.'
+      })
+      setFlashVisible(true)
+    }
   }
 
   useEffect(() => {

--- a/src/components/shoppingList/shoppingList.module.css
+++ b/src/components/shoppingList/shoppingList.module.css
@@ -50,6 +50,10 @@
   color: var(--scheme-color-lightest);
 }
 
+.icon:first-of-type {
+  margin-right: 8px;
+}
+
 .collapsible {
   border: 1px solid var(--border-color);
 }

--- a/src/components/shoppingListPageContent/shoppingListPageContent.js
+++ b/src/components/shoppingListPageContent/shoppingListPageContent.js
@@ -24,8 +24,6 @@ const ShoppingListPageContent = () => {
    * 
    */
 
-  console.log('shoppingLists: ', shoppingLists)
-
   if (happyPathNonEmpty) {
     return(
       <>

--- a/src/components/shoppingListPageContent/shoppingListPageContent.js
+++ b/src/components/shoppingListPageContent/shoppingListPageContent.js
@@ -24,6 +24,8 @@ const ShoppingListPageContent = () => {
    * 
    */
 
+  console.log('shoppingLists: ', shoppingLists)
+
   if (happyPathNonEmpty) {
     return(
       <>

--- a/src/contexts/shoppingListContext.js
+++ b/src/contexts/shoppingListContext.js
@@ -226,6 +226,8 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
           throw new Error('You can\'t delete your master list as it is managed automatically.')
         } else if (resp.status === 404) {
           throw new Error('Shopping list could not be destroyed. Try refreshing to fix this problem.')
+        } else if (resp.status === 204) {
+          return null
         } else {
           return resp.json()
         }
@@ -235,6 +237,14 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
           // This means that the list was the user's last shopping list and both
           // it and the master list have been destroyed.
           setShoppingLists([])
+          setFlashProps({
+            type: 'success',
+            header: 'Your shopping list has been deleted.',
+            message: 'Since it was your last list, your master list has been deleted as well.'
+          })
+
+          setFlashVisible(true)
+
           success && success()
         } else {
           // This means that the master list has been updated and returned,
@@ -243,6 +253,14 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
                                                 .filter(list => list.id !== listId)
 
           setShoppingLists(newShoppingLists)
+
+          setFlashProps({
+            type: 'success',
+            message: 'Your shopping list has been deleted.'
+          })
+
+          setFlashVisible(true)
+
           success && success()
         }
       })

--- a/src/contexts/shoppingListContext.js
+++ b/src/contexts/shoppingListContext.js
@@ -273,6 +273,8 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
     performShoppingListDelete,
     flashProps,
     flashVisible,
+    setFlashProps,
+    setFlashVisible,
     ...overrideValue
   }
 

--- a/src/contexts/shoppingListContext.js
+++ b/src/contexts/shoppingListContext.js
@@ -13,7 +13,12 @@
 import { createContext, useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import logOutWithGoogle from '../utils/logOutWithGoogle'
-import { createShoppingList, fetchShoppingLists, updateShoppingList } from '../utils/simApi'
+import {
+  createShoppingList,
+  fetchShoppingLists,
+  updateShoppingList,
+  deleteShoppingList
+} from '../utils/simApi'
 import { useDashboardContext } from '../hooks/contexts'
 import paths from '../routing/paths'
 
@@ -129,11 +134,6 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
       }) 
   }
 
-  // Note that the success callback will be executed if the API response didn't error
-  // out or return a 401. That means it will still run if the list could not be
-  // created. Only when the API call raises an actual error will the error callback
-  // be called instead. The error callback will not run on a 401 error because that
-  // triggers a redirect.
   const performShoppingListCreate = (title, success = null, error = null) => {
     createShoppingList(token, { title })
       .then(resp => resp.json())
@@ -167,8 +167,9 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
             message: 'Success! Your list was created.'
           })
 
-          success && success()
           setFlashVisible(true)
+
+          success && success()
         } else if (data && data.errors && data.errors.title) {
           // The list couldn't be created because of errors. Since "title" is the only field
           // the UI provides where there could be errors, we'll just assume that's the only
@@ -180,6 +181,7 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
             header: `${data.errors.title.length} error(s) prevented your shopping list from being created:`,
             message: data.errors.title.map(msg => `Title ${msg}`)
           })
+
           setFlashVisible(true)
 
           success && success()
@@ -215,11 +217,60 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
       })
   }
 
+  const performShoppingListDelete = (listId, success = null, error = null) => {
+    deleteShoppingList(token, listId)
+      .then(resp => {
+        if (resp.status === 405) {
+          // This should never happen given there isn't actually a way to even
+          // make this request on a master list through the UI.
+          throw new Error('You can\'t delete your master list as it is managed automatically.')
+        } else if (resp.status === 404) {
+          throw new Error('Shopping list could not be destroyed. Try refreshing to fix this problem.')
+        } else {
+          return resp.json()
+        }
+      })
+      .then(data => {
+        if (!data) {
+          // This means that the list was the user's last shopping list and both
+          // it and the master list have been destroyed.
+          setShoppingLists([])
+          success && success()
+        } else {
+          // This means that the master list has been updated and returned,
+          // to adjust for any items that were deleted with the other list.
+          const newShoppingLists = shoppingLists.map(list => (list.master === true ? data.master_list : list))
+                                                .filter(list => list.id !== listId)
+
+          setShoppingLists(newShoppingLists)
+          success && success()
+        }
+      })
+      .catch(err => {
+        if (err.code === 401) {
+          logOutWithGoogle(() => {
+            token && removeSessionCookie()
+            setShouldRedirectTo(paths.login)
+            mountedRef.current = false
+          })
+        } else {
+          setFlashProps({
+            type: 'error',
+            message: err.message
+          })
+
+          setFlashVisible(true)
+          error && error()
+        }
+      })
+  }
+
   const value = {
     shoppingLists,
     shoppingListLoadingState,
     performShoppingListUpdate,
     performShoppingListCreate,
+    performShoppingListDelete,
     flashProps,
     flashVisible,
     ...overrideValue

--- a/src/pages/dashboardPage/dashboardPage.js
+++ b/src/pages/dashboardPage/dashboardPage.js
@@ -17,15 +17,15 @@ import styles from './dashboardPage.module.css'
 const cards = [
   {
     colorScheme: YELLOW,
-    href: paths.dashboard.shoppingLists,
-    children: 'Your Shopping Lists',
-    key: 'shopping-lists'
+    href: '#',
+    children: 'Your Games',
+    key: 'your-games'
   },
   {
     colorScheme: PINK,
     href: '#',
-    children: 'Nav Link 2',
-    key: 'nav-link-2'
+    children: 'Your Shopping Lists',
+    key: 'your-shopping-lists'
   },
   {
     colorScheme: BLUE,

--- a/src/pages/dashboardPage/dashboardPage.js
+++ b/src/pages/dashboardPage/dashboardPage.js
@@ -23,7 +23,7 @@ const cards = [
   },
   {
     colorScheme: PINK,
-    href: '#',
+    href: paths.dashboard.shoppingLists,
     children: 'Your Shopping Lists',
     key: 'your-shopping-lists'
   },

--- a/src/pages/shoppingListPage/shoppingListPage.stories.js
+++ b/src/pages/shoppingListPage/shoppingListPage.stories.js
@@ -62,6 +62,11 @@ HappyPath.story = {
           ctx.status(200),
           ctx.json(returnData)
         )
+      }),
+      rest.delete(`${backendBaseUri[process.env.NODE_ENV]}/shopping_lists/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(204)
+        )
       })
     ]
   }

--- a/src/pages/shoppingListPage/shoppingListPage.stories.js
+++ b/src/pages/shoppingListPage/shoppingListPage.stories.js
@@ -65,7 +65,16 @@ HappyPath.story = {
       }),
       rest.delete(`${backendBaseUri[process.env.NODE_ENV]}/shopping_lists/:id`, (req, res, ctx) => {
         return res(
-          ctx.status(204)
+          ctx.status(200),
+          ctx.json({
+            master_list: {
+              id: 489,
+              title: 'Master',
+              master: true,
+              user_id: 24,
+              shopping_list_items: []
+            }
+          })
         )
       })
     ]
@@ -79,7 +88,7 @@ HappyPath.story = {
  * 
  */
 
-export const UpdateListNotFound = () => (
+export const ListNotFound = () => (
   <DashboardProvider overrideValue={dashboardContextOverrideValue}>
     <ShoppingListProvider>
       <ShoppingListPage />
@@ -87,7 +96,7 @@ export const UpdateListNotFound = () => (
   </DashboardProvider>
 )
 
-UpdateListNotFound.story = {
+ListNotFound.story = {
   parameters: {
     msw: [
       rest.get(`${backendBaseUri[process.env.NODE_ENV]}/shopping_lists`, (req, res, ctx) => {
@@ -111,6 +120,16 @@ UpdateListNotFound.story = {
         return res(
           ctx.status(404),
           ctx.json({ error: `Shopping list id=${listId} not found` })
+        )
+      }),
+      rest.delete(`${backendBaseUri[process.env.NODE_ENV]}/shopping_lists/:id`, (req, res, ctx) => {
+        const listId = Number(req.params.id)
+
+        return res(
+          ctx.status(404),
+          ctx.json({
+            error: `Shopping list id=${listId} not found`
+          })
         )
       })
     ]
@@ -151,6 +170,22 @@ UnprocessableEntity.story = {
         return res(
           ctx.status(422),
           ctx.json({ errors: { title: ['is already taken'] } })
+        )
+      }),
+      rest.delete(`${backendBaseUri[process.env.NODE_ENV]}/shopping_lists/:id`, (req, res, ctx) => {
+        const listId = Number(req.params.id)
+
+        return res(
+          ctx.status(200),
+          ctx.json({
+            master_list: {
+              id: 93,
+              title: 'Master',
+              master: true,
+              user_id: 24,
+              shopping_list_items: []
+            }
+          })
         )
       })
     ]
@@ -200,6 +235,13 @@ Empty.story = {
         return res(
           ctx.status(200),
           ctx.json(returnData)
+        )
+      }),
+      rest.delete(`${backendBaseUri[process.env.NODE_ENV]}/shopping_lists/:id`, (req, res, ctx) => {
+        const listId = Number(req.params.id)
+
+        return res(
+          ctx.status(204)
         )
       })
     ]

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -63,7 +63,7 @@ export const fetchUserProfile = token => {
  *
  */
 
-// GET index
+// GET /shopping_lists
 export const fetchShoppingLists = token => {
   const uri = `${baseUri}/shopping_lists`
 
@@ -76,7 +76,7 @@ export const fetchShoppingLists = token => {
   )
 }
 
-// POST create
+// POST /shopping_lists
 export const createShoppingList = (token, attrs) => {
   const uri = `${baseUri}/shopping_lists`
   const body = JSON.stringify({ shopping_list: attrs })
@@ -92,7 +92,7 @@ export const createShoppingList = (token, attrs) => {
   })
 }
 
-// PATCH update
+// PATCH /shopping_lists/:id
 export const updateShoppingList = (token, listId, attrs) => {
   const uri = `${baseUri}/shopping_lists/${listId}`
 
@@ -106,6 +106,22 @@ export const updateShoppingList = (token, listId, attrs) => {
       method: 'PATCH',
       headers: combinedHeaders(token),
       body: body
+    })
+    .then(resp => {
+      if (resp.status === 401) throw new AuthorizationError()
+      return resp
+    })
+  )
+}
+
+// DELETE /shopping_lists/:id
+export const deleteShoppingList = (token, listId) => {
+  const uri = `${baseUri}/shopping_lists/${listId}`
+
+  return(
+    fetch(uri, {
+      method: 'DELETE',
+      headers: authHeader(token),
     })
     .then(resp => {
       if (resp.status === 401) throw new AuthorizationError()


### PR DESCRIPTION
## Context

[**Enable user to remove shopping lists from the UI**](https://trello.com/c/jFhlvLdj/21-enable-user-to-remove-shopping-lists-from-the-ui)

Currently, users can view, create, or edit the title of their shopping lists in their dashboard, but they can't remove a shopping list.

## Changes

* Enable users to delete shopping lists from their dashboard using an X icon
* Prompt users before deleting their lists

## Considerations

This was a relatively straightforward card that didn't require much in the way of architectural or major design changes. 

## Screenshots and GIFs

### Deleting a List When It Is the Last One


This GIF turned out really weird. It actually shows a green flash message indicating both lists were deleted but you can't really see that in the GIF.

![issue-21-1](https://user-images.githubusercontent.com/5115928/123917055-b3027700-d9c5-11eb-82c7-9054792200ad.gif)

### Clicking Cancel When Prompted

![issue-21-2](https://user-images.githubusercontent.com/5115928/123917095-c01f6600-d9c5-11eb-8d3a-05b472d44836.gif)

### Deleting a List When It Is not the Last One

![issue-21-3](https://user-images.githubusercontent.com/5115928/123917126-c9a8ce00-d9c5-11eb-8cb6-e71b1e6cc7de.gif)

