### PR TITLE
Fix infinite loops when fetching api data fails

### DIFF
--- a/src/contexts/dashboardContext.js
+++ b/src/contexts/dashboardContext.js
@@ -33,12 +33,16 @@ const DashboardContext = createContext()
 const DashboardProvider = ({ children, overrideValue = {} }) => {
   const [cookies, , removeCookie] = useCookies([sessionCookieName])
   const [profileData, setProfileData] = useState(overrideValue.profileData)
-  const [shouldRedirectTo, setShouldRedirectTo] = useState(overrideValue.shouldRedirectTo)
+  const [redirectPath, setRedirectPath] = useState(overrideValue.shouldRedirectTo)
   const [profileLoadState, setProfileLoadState] = useState(overrideValue.profileLoadState || LOADING)
 
   const mountedRef = useRef(true)
 
   const removeSessionCookie = () => overrideValue.removeSessionCookie || removeCookie(sessionCookieName)
+  const setShouldRedirectTo = path => {
+    setRedirectPath(path)
+    mountedRef.current = false
+  }
 
   const value = {
     token: cookies[sessionCookieName],
@@ -65,13 +69,11 @@ const DashboardProvider = ({ children, overrideValue = {} }) => {
           logOutWithGoogle(() => {
             cookies[sessionCookieName] && removeSessionCookie()
             setShouldRedirectTo(paths.login)
-            mountedRef.current = false
           })
         })
     } else if (!cookies[sessionCookieName] && !isStorybook()) {
       logOutWithGoogle(() => {
         setShouldRedirectTo(paths.login)
-        mountedRef.current = false
       })
     } else if (isStorybook() && !overrideValue.profileLoadState) setProfileLoadState(DONE) 
   }
@@ -83,7 +85,7 @@ const DashboardProvider = ({ children, overrideValue = {} }) => {
 
   return(
     <DashboardContext.Provider value={value}>
-      {shouldRedirectTo ? <Redirect to={shouldRedirectTo} /> : children}
+      {redirectPath ? <Redirect to={redirectPath} /> : children}
     </DashboardContext.Provider>
   )
 }

--- a/src/contexts/dashboardContext.js
+++ b/src/contexts/dashboardContext.js
@@ -38,7 +38,7 @@ const DashboardProvider = ({ children, overrideValue = {} }) => {
 
   const mountedRef = useRef(true)
 
-  const removeSessionCookie = () => overrideValue.removeSessionCookie || removeCookie(sessionCookieName)
+  const removeSessionCookie = () => overrideValue.removeSessionCookie() || removeCookie(sessionCookieName)
   const setShouldRedirectTo = path => {
     setRedirectPath(path)
     mountedRef.current = false

--- a/src/pages/loginPage/loginPage.js
+++ b/src/pages/loginPage/loginPage.js
@@ -22,19 +22,18 @@ const LoginPage = () => {
 
     if (cookies[sessionCookieName] !== tokenId) {
       authorize(tokenId)
-      .then(response => {
-        if (response.status === 204) {
-          setCookie(sessionCookieName, tokenId)
-        }
-      })
-      .catch(error => {
-        console.error('Error from /auth/verify_token: ', error.message)
-
-        logOutWithGoogle(() => {
-          cookies[sessionCookieName] && removeCookie(sessionCookieName)
-          return <Redirect to={paths.home} />
+        .then(response => {
+          if (response.status === 204) {
+            setCookie(sessionCookieName, tokenId)
+          }
         })
-      })
+        .catch(error => {
+          console.error('Error from /auth/verify_token: ', error.message)
+
+          logOutWithGoogle(() => {
+            cookies[sessionCookieName] && removeCookie(sessionCookieName)
+          })
+        })
     }
   }
 


### PR DESCRIPTION
## Context

[**Infinite loops when fetching API data fails**](https://trello.com/c/MW3fPinp/51-infinite-loops-when-fetching-api-data-fails)

There was a bug, present in development and production, where, if a user's token expired while they were still on their dashboard, refreshing or navigating to another dashboard page led to an infinite loop:

1. The dashboard requested `GET /users/current` with the existing token, receiving a 401 response from the server
2. The user was redirected to the login page
3. The login page ran the Google Sign In callback and also received a 401 response
4. The login page directed the user to the homepage without setting the cookie first
4. The homepage redirected to the dashboard without verifying that the cookie was still valid
5. The dashboard requested `GET /users/current` with the existing token, receiving a 401 response from the server
6. Etc.

## Changes

* Remove redirect to `home` on unsuccessful login so user stays on the login page
* Fix potential memory leak by making sure that the `DashboardProvider` is unmounted after redirect

## Considerations

Originally I didn't want to change the redirect behaviour, but realised that it would be better UX for the user to stay on the login page after unsuccessful login anyway. Unfortunately, login is only considered unsuccessful until the Google Sign In callback is successful, though, so in the case leading to this bug, the user is taken from their dashboard to the login page and then, assuming they haven't invalidated the token through Google, are immediately redirected back to the dashboard without even clicking anything. Annoying but nowhere near as annoying as the infinite loop that could only be broken by entering a new URL and navigating away.

## Manual Test Cases

This one takes a while to test and there are two main cases.

### Refreshing the Dashboard

1. Visit SIM and log in
2. Wait for half an hour or until your token expires (removing the cookie will not reproduce this bug or verify the fix)
3. Reload the page with your console open
4. See a single 401 response from the server
5. See that you are redirected to the login page (you may be immediately logged back in - that's OK for now)

### Navigating to Another Dashboard Page

Follow the same steps as above, except this time navigate from the dashboard page to the shopping lists page (or vice versa) instead of reloading.