### PR TITLE
Make Flash element disappear when a second request is made

### DIFF
--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -71,6 +71,8 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
   const submitAndHideForm = e => {
     e.preventDefault()
 
+    setFlashVisible(false)
+
     const newTitle = e.nativeEvent.target.children[0].defaultValue
 
     if (!newTitle || isValid(newTitle)) setCurrentTitle(newTitle)
@@ -84,6 +86,8 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
 
     const confirmed = window.confirm(`Are you sure you want to delete the list "${title}"? You will also lose any list items on the list. This action cannot be undone.`)
 
+    setFlashVisible(false)
+
     if (confirmed) {
       performShoppingListDelete(listId)
     } else {
@@ -93,6 +97,7 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
       })
       setFlashVisible(true)
     }
+
   }
 
   useEffect(() => {

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -97,7 +97,6 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
       })
       setFlashVisible(true)
     }
-
   }
 
   useEffect(() => {

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -6,7 +6,11 @@ import styles from './shoppingListCreateForm.module.css'
 import classNames from 'classnames'
 
 const ShoppingListCreateForm = ({ disabled }) => {
-  const { performShoppingListCreate } = useShoppingListContext()
+  const {
+    performShoppingListCreate,
+    setFlashVisible
+  } = useShoppingListContext()
+
   const [inputValue, setInputValue] = useState('')
 
   const colorVars = {
@@ -23,6 +27,7 @@ const ShoppingListCreateForm = ({ disabled }) => {
 
   const createShoppingList = e => {
     e.preventDefault()
+    setFlashVisible(false)
     const title = e.nativeEvent.target.children[0].children[0].defaultValue
     performShoppingListCreate(title, () => setInputValue(''))
   }


### PR DESCRIPTION
## Context

[**Ensure flash message hidden if user submits edit form again**](https://trello.com/c/XyBjEZfJ/42-ensure-flash-message-hidden-if-user-submits-edit-form-again)

Flash messages that appeared on the dashboard were not going away until the user refreshed the page. The flash messages should be hidden any time a form is submitted. That way, there'll be a moment when the flash element isn't visible before the next one appears, making it easier for users to tell that their request got a response. This is especially true in the case where creating or editing a shopping list could fail with the same message twice in a row and the view would not appear to change.

## Changes

* Hide the flash form on submission of the create & edit forms for shopping lists, as well as when the delete icon is clicked

## Considerations

When a user deletes a shopping list, they are first asked to confirm if they want to delete the list and all its list items. If they click OK, the API call is made to delete the list, with the flash message being shown again when the API call is complete. If they click cancel, a flash message appears telling them their list was not deleted. Since `confirm` blocks the process, the `setFlashVisible` call doesn't run until after the user has either confirmed or cancelled. In the case where they've cancelled, the second flash message doesn't have to wait for an API call to finish before it appears, so the change from one flash message to the next is instantaneous. I tried using a `setTimeout` to produce a slight delay but this didn't work so well.

The card also indicates that the flash element should be hidden using `visibility: hidden` instead of `display: none` in order to keep space in the DOM so content doesn't jump around on the page. This proved complicated, though, since we don't actually know the height of the flash message as it is based on content. The only alternative I could see to letting content jump was leaving a conspicuously large space at the top of the page all the time so the flash message can appear in that space whenever it's visible and just hopefully not be longer than the space allows. That seemed unaesthetic and could even make users think something on the page hasn't loaded yet. I decided to let the content jump a bit.

## Manual Test Cases

For this card, just add, edit, and delete items without navigating away or refreshing the page. See that there is a break between the time one flash message disappears and the next one appears (except, as noted above, if you click "cancel" when asked to confirm deletion of a list).
