### PR TITLE
Refactor error handling in promise chains

### DIFF
--- a/src/contexts/shoppingListContext.js
+++ b/src/contexts/shoppingListContext.js
@@ -118,6 +118,16 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
             setShouldRedirectTo(paths.login)
             mountedRef.current = false
           })
+        } else if (err.code === 404) {
+          setFlashProps({
+            type: 'error',
+            message: err.message
+          })
+
+          setFlashVisible(true)
+          overrideValue.shoppingListLoadingState === undefined && setShoppingListLoadingState(DONE)
+          
+          error && error()
         } else {
           overrideValue.shoppingListLoadingState === undefined && setShoppingListLoadingState(ERROR)
 

--- a/src/contexts/shoppingListContext.js
+++ b/src/contexts/shoppingListContext.js
@@ -124,19 +124,18 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
             message: err.message
           })
 
-          setFlashVisible(true)
+          overrideValue.setFlashVisible === undefined && setFlashVisible(true)
           overrideValue.shoppingListLoadingState === undefined && setShoppingListLoadingState(DONE)
           
           error && error()
         } else {
-          overrideValue.shoppingListLoadingState === undefined && setShoppingListLoadingState(ERROR)
-
           setFlashProps({
             type: 'error',
             message: err.message
           })
-
+          
           overrideValue.setFlashVisible === undefined && setFlashVisible(true)
+          overrideValue.shoppingListLoadingState === undefined && setShoppingListLoadingState(ERROR)
 
           error && error()
         }

--- a/src/utils/customErrors.js
+++ b/src/utils/customErrors.js
@@ -6,3 +6,21 @@ export function AuthorizationError(message = '401 Unauthorized') {
 }
 
 AuthorizationError.prototype = new Error()
+
+export function NotFoundError(message = '404 Not Found') {
+  this.message = message
+  this.code = 404
+  this.name = 'NotFoundError'
+  this.stack = (new Error()).stack
+}
+
+NotFoundError.prototype = new Error()
+
+export function MethodNotAllowedError(message = '405 Method Not Allowed') {
+  this.message = message
+  this.code = 405
+  this.name = 'MethodNotAllowedError'
+  this.stack = (new Error()).stack
+}
+
+MethodNotAllowedError.prototype = new Error()

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -14,7 +14,11 @@
  */
 
 import { backendBaseUri } from './config'
-import { AuthorizationError } from './customErrors'
+import {
+  AuthorizationError,
+  MethodNotAllowedError,
+  NotFoundError
+} from './customErrors'
 
 const baseUri = backendBaseUri[process.env.NODE_ENV]
 const authHeader = token => ({ 'Authorization': `Bearer ${token}`})
@@ -109,6 +113,8 @@ export const updateShoppingList = (token, listId, attrs) => {
     })
     .then(resp => {
       if (resp.status === 401) throw new AuthorizationError()
+      if (resp.status === 404) throw new NotFoundError('Shopping list not found. Try refreshing the page to resolve this issue.')
+      if (resp.status === 405) throw new MethodNotAllowedError('Master lists are managed automatically and cannot be updated manually.')
       return resp
     })
   )
@@ -125,6 +131,8 @@ export const deleteShoppingList = (token, listId) => {
     })
     .then(resp => {
       if (resp.status === 401) throw new AuthorizationError()
+      if (resp.status === 404) throw new NotFoundError('Shopping list not found. Try refreshing the page to resolve this issue')
+      if (resp.status === 405) throw new MethodNotAllowedError('Master lists are managed automatically and cannot be deleted manually.')
       return resp
     })
   )

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -131,7 +131,7 @@ export const deleteShoppingList = (token, listId) => {
     })
     .then(resp => {
       if (resp.status === 401) throw new AuthorizationError()
-      if (resp.status === 404) throw new NotFoundError('Shopping list not found. Try refreshing the page to resolve this issue')
+      if (resp.status === 404) throw new NotFoundError('Shopping list not found. Try refreshing the page to resolve this issue.')
       if (resp.status === 405) throw new MethodNotAllowedError('Master lists are managed automatically and cannot be deleted manually.')
       return resp
     })


### PR DESCRIPTION
## Context

[**Refactor error handling in promise chains**](https://trello.com/c/JRyN8FSN/25-refactor-error-handling-in-promise-chains)

There are a few parts of the code where there are really long promise chains that handle errors at different stages. (Generally there are only 2 `then`s and a `catch`, but there's a lot of code in there.) It would be better to handle errors more uniformly and earlier in the process.

## Changes

* Create `NotFoundError` and `MethodNotAllowedError` classes
* Throw these errors in the `simApi` functions if the corresponding status is returned from the server

## Considerations

Unfortunately, a lot of this worked out to just moving code around. We still have to decide which errors' messages we want to show the users and how, some errors (such as 422) require us to access the response body to get more detail so we can't just throw an error as soon as we know that's the status. I think it's still a little bit of an improvement in that it establishes the pattern that an error should be raised early on in the process if possible. It would be really helpful if `response.json()` didn't return a promise so we could access the status code and the JSON body both in the first `then`.

## Manual Test Cases

This affects everything. Make sure that lists can still be fetched, updated, created, and destroyed and check the error cases for each of those operations. This is mainly a refactor so nothing major should be changed (error messages have changed a little).