### PR TITLE
Toggle shopping list item when user clicks anywhere on visible portion

### DIFF
--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -46,12 +46,18 @@ const ShoppingListItem = ({
   const mountedRef = useRef(true)
   const editRef = useRef(null)
   const deleteRef = useRef(null)
+  const incRef = useRef(null)
+  const decRef = useRef(null)
 
-  const editRefContains = el => editRef.current && (editRef.current === el || editRef.current.contains(el))
-  const deleteRefContains = el => deleteRef.current && (deleteRef.current === el || deleteRef.current.contains(el))
+  const refContains = (ref, el) => ref.current && (ref.current === el || ref.current.contains(el))
+  const editRefContains = el => refContains(editRef, el)
+  const deleteRefContains = el => refContains(deleteRef, el)
+  const incRefContains = el => refContains(incRef, el)
+  const decRefContains = el => refContains(decRef, el)
+  const iconContains = el => editRefContains(el) || deleteRefContains(el) || incRefContains(el) || decRefContains(el)
   
   const toggleDetails = e => {
-    if (!e || (!editRefContains(e.target) && !deleteRefContains(e.target))) setToggleEvent(Date.now)
+    if (!e || !iconContains(e.target)) setToggleEvent(Date.now)
   }
 
   const styleVars = {
@@ -136,27 +142,28 @@ const ShoppingListItem = ({
 
   return(
     <div className={styles.root} style={styleVars}>
-      <div className={styles.headerContainer}>
-        <button className={styles.button} onClick={toggleDetails}>
+      <button className={styles.button} onClick={toggleDetails}>
+        <span className={styles.header}>
           {canEdit &&
             <>
-              <div className={styles.icon} ref={deleteRef} onClick={destroyItem}><FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon)} icon={faTimes} /></div>
+              <div className={styles.icon} ref={deleteRef} onClick={destroyItem}><FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon
+              )} icon={faTimes} /></div>
               <div className={styles.icon} ref={editRef} onClick={showEditForm}><FontAwesomeIcon className={styles.fa} icon={faEdit} /></div>
             </>}
           <h4 className={classNames(styles.description, { [styles.descriptionCanEdit]: canEdit })}>{description}</h4>
-        </button>
+        </span>
         <span className={styles.quantity}>
-          {canEdit && <div className={styles.icon} onClick={incrementQuantity}>
+          {canEdit && <div className={styles.icon} ref={incRef} onClick={incrementQuantity}>
             <FontAwesomeIcon className={styles.fa} icon={faAngleUp} />
           </div>}
           <div className={styles.quantityContent}>
             {currentQuantity}
           </div>
-          {canEdit && <div className={styles.icon} onClick={decrementQuantity}>
+          {canEdit && <div className={styles.icon} ref={decRef} onClick={decrementQuantity}>
             <FontAwesomeIcon className={styles.fa} icon={faAngleDown} />
           </div>}
         </span>
-      </div>
+      </button>
       <SlideToggle toggleEvent={toggleEvent} collapsed>
         {({ setCollapsibleElement }) => (
           <div className={styles.collapsible} ref={setCollapsibleElement}>

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -8,37 +8,36 @@
   background-color: var(--hover-color);
 }
 
-.headerContainer {
-  display: grid;
-  grid-template-columns: 4fr 1fr;
-  border-bottom: 1px solid var(--border-color);
-}
-
 .button {
+  width: 100%;
   background: none;
   border: none;
-  border-right: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
   text-align: left;
   cursor: pointer;
-  padding: 32px 0 32px 24px;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 4fr 1fr;
 }
 
 .fa {
   color: var(--title-text-color);
 }
 
-.icon {
-  display: inline-block;
-}
-
 .destroyIcon {
   margin-right: 8px;
 }
 
+.header {
+  padding: 32px 24px;
+  border-right: 1px solid var(--border-color);
+}
+
 .quantity {
   color: var(--title-text-color);
+  display: inline-block;
   margin: auto 0;
-  padding: 0 24px;
+  padding: 32px 24px;
   display: flex;
   justify-content: space-between;
 }
@@ -48,6 +47,7 @@
 }
 
 .icon {
+  display: inline-block;
   padding: 4px;
   cursor: pointer;
 }


### PR DESCRIPTION
## Context

[**Toggle shopping list item when clicking in quantity field**](https://trello.com/c/yCnlW5t8/60-toggle-shopping-list-item-when-clicking-in-quantity-field)

Previously, clicking on the description of a shopping list item would expand the item, but clicking in the quantity field would not do anything. We wanted to change it so clicking anywhere in the (initially) visible area of the shopping list item - except the edit, delete, increment and decrement icons - would expand or collapse the item.

## Changes

* Ensure that clicking anywhere in the initially visible part of a shopping list item toggles it
* Make sure the item is not toggled if an edit or destroy icon is clicked

## Considerations

This card was mainly just a matter of rearranging a couple elements so the entire header could be a button. This was a little unfortunate because the increment and decrement icons should really be buttons too (for accessibility reasons) and nested buttons aren't allowed or a good idea. But I couldn't think of a better way to do it.

## Manual Test Cases

Make sure that existing functionality still works as far as adding, editing, and deleting shopping list items goes.
