### PR TITLE
Fix scrolling in modal

### DIFF
--- a/src/components/dashboardHeader/dashboardHeader.module.css
+++ b/src/components/dashboardHeader/dashboardHeader.module.css
@@ -74,7 +74,6 @@
 .logoutDropdown {
   display: inline-block;
   position: fixed;
-  max-width: 30%;
   top: 90px;
   right: 16px;
 }

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useShoppingListContext } from '../../hooks/contexts'
 import styles from './shoppingListItemEditForm.module.css'
@@ -6,12 +6,9 @@ import styles from './shoppingListItemEditForm.module.css'
 const ShoppingListItemEditForm = ({ listTitle, elementRef, buttonColor, currentAttributes }) => {
   const { performShoppingListItemUpdate } = useShoppingListContext()
 
-  const [mouseOverNotes, setMouseOverNotes] = useState(false)
-
   const mountedRef = useRef(true)
   const formRef = useRef(null)
   const inputRef = useRef(null)
-  const textAreaRef = useRef(null)
 
   const colorVars = {
     '--button-background-color': buttonColor.schemeColor,
@@ -20,7 +17,7 @@ const ShoppingListItemEditForm = ({ listTitle, elementRef, buttonColor, currentA
     '--button-border-color': buttonColor.borderColor
   }
 
-  const updateItem = (e) => {
+  const updateItem = e => {
     e.preventDefault()
 
     const quantity = e.target.elements.quantity.value
@@ -33,37 +30,12 @@ const ShoppingListItemEditForm = ({ listTitle, elementRef, buttonColor, currentA
   }
 
   useEffect(() => {
-    const textAreaHasScrollbar = () => {
-      return textAreaRef.current.clientHeight < textAreaRef.current.scrollHeight
-    }
-
-    const handleKeyboardScroll = e => {
-      if ([38, 40].indexOf(e.code) !== -1) e.preventDefault()
-    }
-
-    const handleScroll = e => {
-      if (textAreaRef.current !== e.target && !textAreaRef.contains(e.target)) e.preventDefault()
-    }
-
-    const handleWheelScroll = e => {
-      if (!mouseOverNotes || !textAreaHasScrollbar()) {
-        e.preventDefault()
-      }
-    }
-
-    window.addEventListener('touchmove', handleScroll)
-    window.addEventListener('keydown', handleKeyboardScroll)
-    window.addEventListener('wheel', handleWheelScroll, { passive: false })
+    document.getElementsByTagName('body')[0].classList.add('modal-open')
+    inputRef && inputRef.current.focus()
 
     return () => {
-      window.removeEventListener('touchmove', handleScroll)
-      window.removeEventListener('keydown', handleKeyboardScroll)
-      window.removeEventListener('wheel', handleWheelScroll)
+      document.getElementsByTagName('body')[0].classList.remove('modal-open')
     }
-  }, [mouseOverNotes])
-
-  useEffect(() => {
-    inputRef && inputRef.current.focus()
   }, [])
 
   return(
@@ -81,10 +53,7 @@ const ShoppingListItemEditForm = ({ listTitle, elementRef, buttonColor, currentA
             className={styles.input}
             type='text'
             name='notes'
-            ref={textAreaRef}
             defaultValue={currentAttributes.notes}
-            onMouseEnter={() => setMouseOverNotes(true)}
-            onMouseOut={() => setMouseOverNotes(false)}
           />
         </fieldset>
         <button className={styles.submit}>Update Item</button>

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,10 @@ body {
   background-color: #000;
 }
 
+body.modal-open {
+  overflow: hidden;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;

--- a/src/pages/shoppingListPage/shoppingListPage.js
+++ b/src/pages/shoppingListPage/shoppingListPage.js
@@ -23,12 +23,16 @@ const ShoppingListPage = () => {
   const formRefContains = el => formRef.current && (formRef.current === el || formRef.current.contains(el))
 
   const hideForm = e => {
-    if (e.key === 'Escape' || !formRefContains(e.target)) setListItemEditFormVisible(false)
+    if (e.key === 'Escape' || !formRefContains(e.target)) {
+      setListItemEditFormVisible(false)
+    }
   }
 
   useEffect(() => {
     window.addEventListener('keyup', hideForm)
-  })
+
+    return () => window.removeEventListener('keyup', hideForm)
+  }, [hideForm])
 
   return(
     <DashboardLayout title='Your Shopping Lists'>


### PR DESCRIPTION
## Context

When a user has the shopping list item edit form modal open, they should be able to scroll inside the `notes` field of the modal but the body should not scroll. I tried a number of approaches to avoid having to do anything to the `body` element itself to prevent scrolling but it turns out there are an awful lot of edge cases that kept stymying any attempt to keep things limited to that one component.

Additionally, the `LogoutDropdown` was wrapping onto multiple lines on narrower screens and I didn't want that so I fixed it in this PR too.

## Changes

* Fix scrolling behaviour when the shopping list item edit form modal is open
* Fix wrapping on logout dropdown at smaller viewport widths

## Considerations

I tried a number of things to make sure you could only scroll in the `Notes` field of the modal, primarily adding event listeners for the events that cause scrolling and preventing them under most circumstances (e.g. not if the mouse was over the `Notes` field). Unfortunately, edge cases kept popping up. What if the notes field doesn't have a scrollbar? (The body scrolls again.) What if the notes field has a scrollbar but can't scroll any more in the given direction? (The body scrolls again.) So I finally said fuck it and added a `modal-open` class to the body to hide the overflow, like Bootstrap does.

## Manual Test Cases

1. Open a shopping list edit form
2. Try scrolling with the scroll wheel, touchpad, or arrow keys (or use a touchmove if on mobile/tablet)
3. See that it doesn't work unless you are over the `Notes` field of the modal AND the `Notes` field has enough text in it to scroll
