### PR TITLE
Fix header bar visuals in Safari

### DIFF
--- a/src/components/dashboardHeader/dashboardHeader.js
+++ b/src/components/dashboardHeader/dashboardHeader.js
@@ -42,7 +42,7 @@ const DashboardHeader = () => {
             <Link className={styles.headerLinkSmall} to={paths.dashboard.main}>S. I. M.</Link>
           </h1>
         </span>
-        {!!profileData ?
+        {profileData ?
         <button className={styles.profile} onClick={() => setDropdownVisible(!dropdownVisible)}>
           <div className={styles.profileText}>
             <p className={styles.textTop}>{profileData.name}</p>

--- a/src/components/dashboardHeader/dashboardHeader.module.css
+++ b/src/components/dashboardHeader/dashboardHeader.module.css
@@ -37,8 +37,7 @@
 .profile {
   background-color: #000;
   border: none;
-  display: grid;
-  grid-template-columns: 2fr 1fr;
+  display: flex;
   cursor: pointer;
 }
 
@@ -57,18 +56,20 @@
 
 .textTop {
   margin-bottom: 2px;
+  vertical-align: bottom;
 }
 
 .textBottom {
   margin-top: 2px;
+  vertical-align: top;
 }
 
 .avatar {
-  height: 64px;
-  width: 64px;
+  height: 52px;
+  width: 52px;
   border-radius: 50%;
   box-shadow: 0px 0px 12px #fff;
-  margin-left: 24px;
+  margin: auto 0 auto 24px;
 }
 
 .logoutDropdown {

--- a/src/pages/loginPage/loginPage.js
+++ b/src/pages/loginPage/loginPage.js
@@ -4,12 +4,9 @@ import {
   googleClientId,
   frontendBaseUri
 } from '../../utils/config'
-import { authorize } from '../../utils/simApi'
-import isStorybook from '../../utils/isStorybook'
 import { useAppContext } from '../../hooks/contexts'
 import paths from '../../routing/paths'
 import styles from './loginPage.module.css'
-import logOutWithGoogle from '../../utils/logOutWithGoogle'
 
 const LoginPage = () => {
   const {


### PR DESCRIPTION
## Context

While testing the shopping list feature on iPad, I discovered that somehow the issues with the header bar that we had previously have come back in Safari (I was able to reproduce on Mac and it was the same issue, see screenshots).

Additionally, I noticed that there were sometimes some issues with a login being successful but the backend rejecting the API call with a 401 anyway. I've tried making sure that a new cookie is set each time login succeeds, although I'm not sure that'll work given the token is only sent to the server in the `Authorization` header and that doesn't include the expiration. It does seem to be the same token every time.

I also made sure that if the cookie is present but, for some reason, no token ID is returned from Google, the cookie is removed in the success callback. Hopefully this will fix some of the issues we've been having.

## Changes

* Fix header bar in Safari
* Set session cookie on every response from Google
* Remove session cookie if Google doesn't return a token ID

## Considerations

I was surprised that the previous fix for the header bar didn't work in Safari, but I imagine the UX fixes we did at the end of the shopping list epic mucked things up again. I was a little leery about changing the `display` from `grid` to `flex` on the `.profile` element but it didn't seem to cause any problems in Safari or Chrome, which are the only browsers I really use, so that's good enough.

## Screenshots and GIFs

### Before

<img width="1680" alt="Screen Shot 2021-07-12 at 8 55 34 am" src="https://user-images.githubusercontent.com/5115928/125212325-f4f9ba00-e2ef-11eb-8388-662154b0651d.png">

### After

<img width="1680" alt="Screen Shot 2021-07-12 at 8 54 16 am" src="https://user-images.githubusercontent.com/5115928/125212328-fb883180-e2ef-11eb-947b-6054b064c56d.png">
