### PR TITLE
Fix issue with grid columns in Safari

### DIFF
--- a/src/components/shoppingListEditForm/shoppingListEditForm.js
+++ b/src/components/shoppingListEditForm/shoppingListEditForm.js
@@ -13,8 +13,9 @@ const ShoppingListEditForm = ({ formRef, maxTotalWidth, className, title, onSubm
     context.font = '21px Quattrocento Sans'
 
     const max = (maxTextWidth || maxTotalWidth)
+    const textWidth = context.measureText(text).width * 1.1
 
-    return Math.min(context.measureText(text).width, max)
+    return Math.min(textWidth, max)
   }
 
   const [inputValue, setInputValue] = useState(title)
@@ -46,7 +47,7 @@ const ShoppingListEditForm = ({ formRef, maxTotalWidth, className, title, onSubm
     if (!buttonRef.current) return setMaxTextWidth(maxTotalWidth)
 
     // 14px of left/right padding in the input
-    setMaxTextWidth(maxTotalWidth - buttonRef.current.offsetWidth - 14)
+    setMaxTextWidth(maxTotalWidth - buttonRef.current.offsetWidth)
   }, [maxTotalWidth])
 
   return(

--- a/src/components/shoppingListEditForm/shoppingListEditForm.js
+++ b/src/components/shoppingListEditForm/shoppingListEditForm.js
@@ -13,6 +13,9 @@ const ShoppingListEditForm = ({ formRef, maxTotalWidth, className, title, onSubm
     context.font = '21px Quattrocento Sans'
 
     const max = (maxTextWidth || maxTotalWidth)
+    
+    // The 1.1 proved necessary to prevent text from scrolling out of the
+    // view prematurely in Safari
     const textWidth = context.measureText(text).width * 1.1
 
     return Math.min(textWidth, max)
@@ -46,7 +49,6 @@ const ShoppingListEditForm = ({ formRef, maxTotalWidth, className, title, onSubm
   useEffect(() => {
     if (!buttonRef.current) return setMaxTextWidth(maxTotalWidth)
 
-    // 14px of left/right padding in the input
     setMaxTextWidth(maxTotalWidth - buttonRef.current.offsetWidth)
   }, [maxTotalWidth])
 

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -144,28 +144,28 @@ const ShoppingListItem = ({
 
   return(
     <div className={styles.root} style={styleVars}>
-      <button className={styles.button} onClick={toggleDetails}>
+      <div className={styles.button} onClick={toggleDetails}>
         <span ref={headerRef} className={classNames(styles.header, { [styles.headerEditable]: canEdit })}>
           {canEdit &&
             <span className={styles.editIcons} ref={iconsRef}>
-              <div className={styles.icon} ref={deleteRef} onClick={destroyItem}><FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon
-              )} icon={faTimes} /></div>
-              <div className={styles.icon} ref={editRef} onClick={showEditForm}><FontAwesomeIcon className={styles.fa} icon={faEdit} /></div>
+              <a className={styles.icon} ref={deleteRef} onClick={destroyItem}><FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon
+              )} icon={faTimes} /></a>
+              <a className={styles.icon} ref={editRef} onClick={showEditForm}><FontAwesomeIcon className={styles.fa} icon={faEdit} /></a>
             </span>}
           <h4 className={styles.description}>{description}</h4>
         </span>
         <span className={styles.quantity}>
-          {canEdit && <div className={styles.icon} ref={incRef} onClick={incrementQuantity}>
+          {canEdit && <a className={styles.icon} ref={incRef} onClick={incrementQuantity}>
             <FontAwesomeIcon className={styles.fa} icon={faAngleUp} />
-          </div>}
+          </a>}
           <div className={styles.quantityContent}>
             {currentQuantity}
           </div>
-          {canEdit && <div className={styles.icon} ref={decRef} onClick={decrementQuantity}>
+          {canEdit && <a className={styles.icon} ref={decRef} onClick={decrementQuantity}>
             <FontAwesomeIcon className={styles.fa} icon={faAngleDown} />
-          </div>}
+          </a>}
         </span>
-      </button>
+      </div>
       <SlideToggle toggleEvent={toggleEvent} collapsed>
         {({ setCollapsibleElement }) => (
           <div className={styles.collapsible} ref={setCollapsibleElement}>

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -144,26 +144,26 @@ const ShoppingListItem = ({
 
   return(
     <div className={styles.root} style={styleVars}>
-      <div className={styles.button} onClick={toggleDetails}>
+      <div className={styles.toggle} onClick={toggleDetails}>
         <span ref={headerRef} className={classNames(styles.header, { [styles.headerEditable]: canEdit })}>
           {canEdit &&
             <span className={styles.editIcons} ref={iconsRef}>
-              <a className={styles.icon} ref={deleteRef} onClick={destroyItem}><FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon
-              )} icon={faTimes} /></a>
-              <a className={styles.icon} ref={editRef} onClick={showEditForm}><FontAwesomeIcon className={styles.fa} icon={faEdit} /></a>
+              <button className={styles.icon} ref={deleteRef} onClick={destroyItem}><FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon
+              )} icon={faTimes} /></button>
+              <button className={styles.icon} ref={editRef} onClick={showEditForm}><FontAwesomeIcon className={styles.fa} icon={faEdit} /></button>
             </span>}
           <h4 className={styles.description}>{description}</h4>
         </span>
         <span className={styles.quantity}>
-          {canEdit && <a className={styles.icon} ref={incRef} onClick={incrementQuantity}>
+          {canEdit && <button className={styles.icon} ref={incRef} onClick={incrementQuantity}>
             <FontAwesomeIcon className={styles.fa} icon={faAngleUp} />
-          </a>}
+          </button>}
           <div className={styles.quantityContent}>
             {currentQuantity}
           </div>
-          {canEdit && <a className={styles.icon} ref={decRef} onClick={decrementQuantity}>
+          {canEdit && <button className={styles.icon} ref={decRef} onClick={decrementQuantity}>
             <FontAwesomeIcon className={styles.fa} icon={faAngleDown} />
-          </a>}
+          </button>}
         </span>
       </div>
       <SlideToggle toggleEvent={toggleEvent} collapsed>

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -8,10 +8,8 @@
   background-color: var(--hover-color);
 }
 
-.button {
+.toggle {
   width: 100%;
-  background: none;
-  border: none;
   border-bottom: 1px solid var(--border-color);
   text-align: left;
   cursor: pointer;
@@ -61,6 +59,8 @@
 
 .icon {
   display: inline-block;
+  background: none;
+  border: none;
   padding: 4px;
   cursor: pointer;
 }
@@ -85,7 +85,7 @@
 }
 
 .notes {
-  padding: 24px;
+  padding: 24px 16px;
   margin: 0;
   line-height: 1.25
 }
@@ -103,6 +103,10 @@
 
   .quantity {
     padding: 32px 16px;
+  }
+
+  .notes {
+    padding: 24px 16px;
   }
 }
 

--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -78,13 +78,15 @@ const AppProvider = ({ children, overrideValue = {} }) => {
           if (!overrideValue.profileLoadState) setProfileLoadState(DONE)
         })
         .catch(error => {
-          console.error('Error returned while fetching profile data: ', error.message)
+          if (process.env.NODE_ENV !== 'production') console.error('Error returned while fetching profile data: ', error.message)
 
           logOutAndRedirect()
         })
     } else if (!cookies[sessionCookieName] && !isStorybook()) {
       logOutAndRedirect()
-    } else if (isStorybook() && !overrideValue.profileLoadState) setProfileLoadState(DONE) 
+    } else if (isStorybook() && !overrideValue.profileLoadState) {
+      setProfileLoadState(DONE)
+    }
   }
 
   useEffect(fetchProfileData, [


### PR DESCRIPTION
## Context

[**Fix visual bugs in Safari**](https://trello.com/c/5xuULpbi/76-fix-visual-bugs-in-safari)

There were some issues where the grid columns in the `ShoppingListItem` component were showing up on separate lines in Safari. The issue turned out to be that Safari didn't like the `button` element being used as a container for the entire slide toggle.

Additionally, on the `ShoppingListEditForm`, when the user entered text in Safari, the text began to scroll out of the input immediately, getting progressively further out of the input even as it expanded.

## Changes

* Change `button` element to be a `div` to fix styles in Safari
* Prevent premature text scrolling in shopping list edit form input in Safari

## Considerations

I tried every-fucking-thing and this was what worked.

## Screenshots and GIFs

### List Item in Safari

<img width="789" alt="Screen Shot 2021-07-12 at 12 23 15 pm" src="https://user-images.githubusercontent.com/5115928/125221739-0cdf3700-e30c-11eb-8a41-4ebf676dd0fd.png">

