### PR TITLE
Make quantity fields numeric on mobile

### DIFF
--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
@@ -65,7 +65,7 @@ const ShoppingListItemCreateForm = ({ listId }) => {
 
               <fieldset className={styles.fieldset}>
                 <label className={styles.label} htmlFor='quantity'>Quantity</label>
-                <input className={styles.input} type='text' name='quantity' placeholder='Quantity' />
+                <input className={styles.input} type='number' name='quantity' placeholder='Quantity' />
               </fieldset>
 
               <fieldset className={styles.fieldset}>

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
@@ -45,7 +45,7 @@ const ShoppingListItemEditForm = ({ listTitle, elementRef, buttonColor, currentA
       <form className={styles.form} ref={formRef} onSubmit={updateItem}>
         <fieldset className={styles.fieldset}>
           <label className={styles.quantityLabel} htmlFor='quantity'>Quantity</label>
-          <input className={styles.input} ref={inputRef} type='text' name='quantity' defaultValue={currentAttributes.quantity} />
+          <input className={styles.input} ref={inputRef} type='number' name='quantity' defaultValue={currentAttributes.quantity} />
         </fieldset>
         <fieldset className={styles.fieldset}>
           <label className={styles.notesLabel} htmlFor='notes'>Notes</label>


### PR DESCRIPTION
## Context

During testing of the shopping lists feature, I realised that the "quantity" fields could be made numeric on mobile and tablet and that would be better UX.

## Changes

* Make quantity fields numeric
