### PR TITLE
Create not found page and incorporate

### DIFF
--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -18,7 +18,7 @@ import { sessionCookieName } from '../utils/config'
 import { fetchUserProfile } from '../utils/simApi'
 import logOutWithGoogle from '../utils/logOutWithGoogle'
 import isStorybook from '../utils/isStorybook'
-import paths from '../routing/paths'
+import paths, { allPaths } from '../routing/paths'
 
 const LOADING = 'loading'
 const DONE = 'done'
@@ -56,7 +56,7 @@ const AppProvider = ({ children, overrideValue = {} }) => {
     ...overrideValue // enables you to only change certain values
   }
 
-  const onAuthenticatedPage = window.location.pathname !== paths.login && window.location.pathname !== paths.home
+  const onAuthenticatedPage = window.location.pathname !== paths.login && window.location.pathname !== paths.home && allPaths.indexOf(window.location.pathname) !== -1
 
   const shouldFetchProfileData = !overrideValue.profileData && cookies[sessionCookieName] && onAuthenticatedPage
 

--- a/src/pages/notFoundPage/notFoundPage.js
+++ b/src/pages/notFoundPage/notFoundPage.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { useAppContext } from '../../hooks/contexts'
+import paths from '../../routing/paths'
+import styles from './notFoundPage.module.css'
+
+const NotFoundPage = () => {
+  const { token } = useAppContext()
+
+  return(
+    <div className={styles.root}>
+      <div className={styles.container}>
+        <h1 className={styles.header}>SIM: Page Not Found</h1>
+        <Link className={styles.link} to={token ? paths.dashboard.main : paths.home}>Go Back</Link>
+      </div>
+    </div>
+  )
+}
+
+export default NotFoundPage

--- a/src/pages/notFoundPage/notFoundPage.module.css
+++ b/src/pages/notFoundPage/notFoundPage.module.css
@@ -14,10 +14,9 @@
   font-family: 'Cinzel Decorative', Arial, Helvetica, sans-serif;
   color: #fff;
   margin: 0 auto 16px;
-  text-align: center;
 }
 
-.login {
+.link {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
   font-size: 1.1rem;
   color: #fff;
@@ -25,6 +24,6 @@
   margin: 0 auto;
 }
 
-.login:hover {
+.link:hover {
   text-decoration: underline;
 }

--- a/src/pages/notFoundPage/notFoundPage.stories.js
+++ b/src/pages/notFoundPage/notFoundPage.stories.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { AppProvider } from '../../contexts/appContext'
+import NotFoundPage from './notFoundPage'
+
+const profileData = {
+  id: 24,
+  uid: 'dragonborn@gmail.com',
+  email: 'dragonborn@gmail.com',
+  name: 'Jane Doe',
+  image_url: null
+}
+
+export default { title: 'NotFoundPage' }
+
+export const Default = () => (
+  <AppProvider overrideValue={{ token: null, profileData }}>
+    <NotFoundPage />
+  </AppProvider>
+)

--- a/src/routing/pageRoutes.js
+++ b/src/routing/pageRoutes.js
@@ -6,6 +6,7 @@ import DashboardPage from '../pages/dashboardPage/dashboardPage'
 import ShoppingListPage from '../pages/shoppingListPage/shoppingListPage'
 import HomePage from '../pages/homePage/homePage'
 import LoginPage from '../pages/loginPage/loginPage'
+import NotFoundPage from '../pages/notFoundPage/notFoundPage'
 import paths from './paths'
 import { ShoppingListProvider } from '../contexts/shoppingListContext'
 
@@ -61,6 +62,17 @@ const PageRoutes = () => (
         )
       }
     )}
+    <Route key='notFound'>
+      <Helmet>
+        <html lang='en' />
+
+        <title>Skyrim Inventory Management | Page Not Found</title>
+        <meta name='description' content='Skyrim Inventory Management could not find the page you were looking for' />
+      </Helmet>
+      <AppProvider>
+        <NotFoundPage />
+      </AppProvider>
+    </Route>
   </Switch>
 )
 

--- a/src/routing/paths.js
+++ b/src/routing/paths.js
@@ -7,4 +7,11 @@ const paths = {
   }
 }
 
+export const allPaths = [
+  '/',
+  '/login',
+  '/dashboard',
+  '/dashboard/shopping_lists'
+]
+
 export default paths


### PR DESCRIPTION
## Context

[**Create 404 page**](https://trello.com/c/gu20XcQI/53-create-404-page)

SIM doesn't have a 404 page yet.

## Changes

* Create 404 page
* Add route for new page

## Considerations

Because the layouts of the home, login, and 404 pages are really similar, I considered extracting a layout but it just seemed like there wasn't enough code to justify that. If there end up being more pages with that layout we should extract it.

I created an `allPaths` array to include all the paths in the app, including those nested within other objects in the `paths` object. It would've been cool to have it automatically, recursively go through the `paths` object and grab all the values but it honestly just wasn't worth the trouble for how few paths there are.

There is a link on the page that goes to the dashboard (if the session cookie is set) or the homepage (if not). I thought this was better UX than having logged-in users sent back to the dashboard.

## Manual Test Cases

### Logged Out

1. Log out of SIM if you are logged in
2. Visit http://localhost:3001/notfound
3. See the Not Found page
4. Click the link
5. See that you are taken to the homepage

### Logged In

1. Log into SIM if you aren't logged in already
2. Visit http://localhost:3001/notfound
3. See the Not Found page
4. Click the link
5. See that you are taken to the dashboard

## Screenshots and GIFs

<img width="1436" alt="Screen Shot 2021-07-12 at 4 54 13 pm" src="https://user-images.githubusercontent.com/5115928/125244122-488cf780-e332-11eb-8dfe-9157234f6a0c.png">
