### PR TITLE
Refine colour schemes

### DIFF
--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -195,11 +195,11 @@ import { useColorScheme } from '../../hooks/contexts'
 import styles from './child.module.css'
 
 const Child = () => {
-  const { schemeColor, hoverColor, textColorPrimary } = useColorScheme()
+  const { schemeColorDarkest, hoverColorDark, textColorPrimary } = useColorScheme()
 
   const styleVars = {
-    '--background-color': schemeColor,
-    '--hover-color': hoverColor,
+    '--background-color': schemeColorDarkest,
+    '--hover-color': hoverColorDark,
     '--text-color': textColorPrimary
   }
 

--- a/src/components/loading/loading.stories.js
+++ b/src/components/loading/loading.stories.js
@@ -7,7 +7,7 @@ export default { title: 'Loading' }
 export const Blank = () => (
   <Loading
     type='blank'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />
@@ -16,7 +16,7 @@ export const Blank = () => (
 export const Balls = () => (
   <Loading
     type='balls'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />
@@ -25,7 +25,7 @@ export const Balls = () => (
 export const Bars = () => (
   <Loading
     type='bars'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />
@@ -34,7 +34,7 @@ export const Bars = () => (
 export const Bubbles = () => (
   <Loading
     type='bubbles'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />
@@ -43,7 +43,7 @@ export const Bubbles = () => (
 export const Cubes = () => (
   <Loading
     type='cubes'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />
@@ -52,7 +52,7 @@ export const Cubes = () => (
 export const Cylon = () => (
   <Loading
     type='cylon'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />
@@ -61,7 +61,7 @@ export const Cylon = () => (
 export const Spin = () => (
   <Loading
     type='spin'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />
@@ -70,7 +70,7 @@ export const Spin = () => (
 export const SpinningBubbles = () => (
   <Loading
     type='spinningBubbles'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />
@@ -79,7 +79,7 @@ export const SpinningBubbles = () => (
 export const Spokes = () => (
   <Loading
     type='spokes'
-    color={AQUA.schemeColor}
+    color={AQUA.schemeColorDarkest}
     height={667}
     width={375}
   />

--- a/src/components/navigationCard/navigationCard.js
+++ b/src/components/navigationCard/navigationCard.js
@@ -5,11 +5,11 @@ import { useColorScheme } from '../../hooks/contexts'
 import styles from './navigationCard.module.css'
 
 const NavigationCard = ({ href, children }) => {
-  const { schemeColor, hoverColor, textColorPrimary} = useColorScheme()
+  const { schemeColorDarkest, hoverColorDark, textColorPrimary} = useColorScheme()
 
   const styleVars = {
-    '--background-color': schemeColor,
-    '--hover-color': hoverColor,
+    '--background-color': schemeColorDarkest,
+    '--hover-color': hoverColorDark,
     '--text-color': textColorPrimary
   }
 

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -58,22 +58,22 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
   }
 
   const {
-    schemeColor,
+    schemeColorDarkest,
     borderColor,
     textColorPrimary,
     textColorSecondary,
-    hoverColor,
-    schemeColorLighter,
+    hoverColorDark,
+    schemeColorDark,
     schemeColorLightest
   } = useColorScheme()
 
   const styleVars = {
-    '--scheme-color': schemeColor,
+    '--scheme-color': schemeColorDarkest,
     '--border-color': borderColor,
     '--text-color-primary': textColorPrimary,
     '--text-color-secondary': textColorSecondary,
-    '--hover-color': hoverColor,
-    '--scheme-color-lighter': schemeColorLighter,
+    '--hover-color': hoverColorDark,
+    '--scheme-color-lighter': schemeColorDark,
     '--scheme-color-lightest': schemeColorLightest,
     '--max-title-width': `${maxEditFormWidth - 32}px`
   }

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -14,10 +14,10 @@ const ShoppingListCreateForm = ({ disabled }) => {
   const [inputValue, setInputValue] = useState('')
 
   const colorVars = {
-    '--button-color': BLUE.schemeColorLighter,
+    '--button-color': BLUE.schemeColorDark,
     '--button-text-color': BLUE.textColorPrimary,
     '--button-border-color': BLUE.borderColor,
-    '--button-hover-color': BLUE.hoverColorLighter,
+    '--button-hover-color': BLUE.hoverColorLight,
   }
 
   const updateValue = e => {

--- a/src/components/shoppingListEditForm/shoppingListEditForm.js
+++ b/src/components/shoppingListEditForm/shoppingListEditForm.js
@@ -27,10 +27,10 @@ const ShoppingListEditForm = ({ formRef, maxTotalWidth, className, title, onSubm
   const inputRef = useRef(null)
   const buttonRef = useRef(null)
 
-  const { schemeColor, textColorPrimary, borderColor, schemeColorLightest } = useColorScheme()
+  const { schemeColorDarkest, textColorPrimary, borderColor, schemeColorLightest } = useColorScheme()
 
   const colorVars = {
-    '--scheme-color': schemeColor,
+    '--scheme-color': schemeColorDarkest,
     '--text-color': textColorPrimary,
     '--border-color': borderColor,
     '--icon-hover-color': schemeColorLightest

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -23,11 +23,11 @@ const ShoppingListItem = ({
   const [currentQuantity, setCurrentQuantity] = useState(quantity)
 
   const {
-    schemeColor,
+    schemeColorDarkest,
     textColorPrimary,
-    hoverColor,
-    schemeColorLighter,
-    hoverColorLighter,
+    hoverColorDark,
+    schemeColorDark,
+    hoverColorLight,
     textColorSecondary,
     borderColor,
     schemeColorLightest,
@@ -63,12 +63,12 @@ const ShoppingListItem = ({
   }
 
   const styleVars = {
-    '--main-color': schemeColorLighter,
+    '--main-color': schemeColorDark,
     '--title-text-color': textColorSecondary,
     '--border-color': borderColor,
     '--body-background-color': schemeColorLightest,
     '--body-text-color': textColorTertiary,
-    '--hover-color': hoverColorLighter
+    '--hover-color': hoverColorLight
   }
 
   const incrementQuantity = () => {
@@ -119,8 +119,8 @@ const ShoppingListItem = ({
     setListItemEditFormProps({
       listTitle: listTitle,
       buttonColor: {
-        schemeColor,
-        hoverColor,
+        schemeColorDarkest,
+        hoverColorDark,
         borderColor,
         textColorPrimary
       },

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
@@ -8,8 +8,8 @@ const ShoppingListItemCreateForm = ({ listId }) => {
   const [toggleEvent, setToggleEvent] = useState(0)
   const { performShoppingListItemCreate, setFlashVisible } = useShoppingListContext()
   const {
-    schemeColorLighter,
-    hoverColorLighter,
+    schemeColorDark,
+    hoverColorLight,
     schemeColorLightest,
     borderColor,
     textColorSecondary,
@@ -19,8 +19,8 @@ const ShoppingListItemCreateForm = ({ listId }) => {
   const formRef = useRef(null)
 
   const colorVars = {
-    '--base-color': schemeColorLighter,
-    '--hover-color': hoverColorLighter,
+    '--base-color': schemeColorDark,
+    '--hover-color': hoverColorLight,
     '--body-color': schemeColorLightest,
     '--border-color': borderColor,
     '--text-color-main': textColorSecondary,

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.module.css
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.module.css
@@ -47,6 +47,7 @@
 
 .input {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  color: var(--text-color-secondary);
   font-size: 1rem;
   border: 1px solid var(--border-color);
   border-radius: 3px;

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
@@ -49,8 +49,7 @@ const ShoppingListItemEditForm = ({ listTitle, elementRef, buttonColor, currentA
             className={styles.input}
             ref={inputRef}
             type='number'
-            inputM
-            ode='numeric'
+            inputMode='numeric'
             name='quantity'
             defaultValue={currentAttributes.quantity}
           />
@@ -76,9 +75,9 @@ ShoppingListItemEditForm.propTypes = {
   }),
   listTitle: PropTypes.string.isRequired,
   buttonColor: PropTypes.shape({
-    schemeColor: PropTypes.string.isRequired,
+    schemeColorDarkest: PropTypes.string.isRequired,
     textColorPrimary: PropTypes.string.isRequired,
-    hoverColor: PropTypes.string.isRequired,
+    hoverColorDark: PropTypes.string.isRequired,
     borderColor: PropTypes.string.isRequired
   }).isRequired,
   currentAttributes: PropTypes.shape({

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
@@ -11,9 +11,9 @@ const ShoppingListItemEditForm = ({ listTitle, elementRef, buttonColor, currentA
   const inputRef = useRef(null)
 
   const colorVars = {
-    '--button-background-color': buttonColor.schemeColor,
+    '--button-background-color': buttonColor.schemeColorDarkest,
     '--button-text-color': buttonColor.textColorPrimary,
-    '--button-hover-color': buttonColor.hoverColor,
+    '--button-hover-color': buttonColor.hoverColorDark,
     '--button-border-color': buttonColor.borderColor
   }
 
@@ -49,7 +49,8 @@ const ShoppingListItemEditForm = ({ listTitle, elementRef, buttonColor, currentA
             className={styles.input}
             ref={inputRef}
             type='number'
-            inputMode='numeric'
+            inputM
+            ode='numeric'
             name='quantity'
             defaultValue={currentAttributes.quantity}
           />

--- a/src/components/shoppingListPageContent/shoppingListPageContent.js
+++ b/src/components/shoppingListPageContent/shoppingListPageContent.js
@@ -48,7 +48,7 @@ const ShoppingListPageContent = () => {
       </>
     )
   } else if (shoppingListLoadingState === 'loading') {
-    return <Loading className={styles.loading} color={YELLOW.schemeColor} height='15%' width='15%' />
+    return <Loading className={styles.loading} color={YELLOW.schemeColorDarkest} height='15%' width='15%' />
   } else {
     return null
   }

--- a/src/contexts/colorContext.js
+++ b/src/contexts/colorContext.js
@@ -21,15 +21,17 @@ const ColorProvider = ({ colorScheme, children }) => {
 
 ColorProvider.propTypes = {
   colorScheme: PropTypes.shape({
-    schemeColor: PropTypes.string.isRequired,
-    hoverColor: PropTypes.string.isRequired,
+    schemeColorDarkest: PropTypes.string.isRequired,
+    schemeColorDark: PropTypes.string.isRequired,
+    schemeColorLight: PropTypes.string.isRequired,
+    schemeColorLightest: PropTypes.string.isRequired,
+    hoverColorDark: PropTypes.string.isRequired,
+    hoverColorLight: PropTypes.string.isRequired,
+    hoverColorLightest: PropTypes.string.isRequired,
     textColorPrimary: PropTypes.string.isRequired,
-    borderColor: PropTypes.string,
-    schemeColorLighter: PropTypes.string,
-    hoverColorLighter: PropTypes.string,
-    schemeColorLightest: PropTypes.string,
     textColorSecondary: PropTypes.string,
-    textColorTertiary: PropTypes.string
+    textColorTertiary: PropTypes.string,
+    borderColor: PropTypes.string
   }).isRequired,
   children: PropTypes.node.isRequired
 }

--- a/src/utils/colorSchemes.js
+++ b/src/utils/colorSchemes.js
@@ -5,6 +5,7 @@ export const YELLOW = {
   schemeColorLightest: '#fff2cc',
   hoverColorDark: '#e5ab00',
   hoverColorLight: '#ffc519',
+  hoverColorLightest: '#ffebb2',
   textColorPrimary: '#4c3900',
   textColorSecondary: '#4c3900',
   textColorTertiary: '#7f5700',

--- a/src/utils/colorSchemes.js
+++ b/src/utils/colorSchemes.js
@@ -1,61 +1,70 @@
 export const YELLOW = {
-  schemeColor: '#FFBF00',
-  hoverColor: '#E5AB00',
-  borderColor: '#CC9800',
-  textColorPrimary: '#000000',
-  schemeColorLighter: '#FFCB32',
-  hoverColorLighter: '#FFC519',
-  textColorSecondary: '#000000',
-  textColorTertiary: '#000000',
-  schemeColorLightest: '#FFF2CC'
+  schemeColorDarkest: '#ffbf00',
+  schemeColorDark: '#ffcb32',
+  schemeColorLight: '#ffd866',
+  schemeColorLightest: '#fff2cc',
+  hoverColorDark: '#e5ab00',
+  hoverColorLight: '#ffc519',
+  textColorPrimary: '#4c3900',
+  textColorSecondary: '#4c3900',
+  textColorTertiary: '#7f5700',
+  borderColor: '#cc9800',
 }
 
 export const PINK = {
-  schemeColor: '#E83F6F',
-  hoverColor: '#D03863',
-  borderColor: '#B93258',
-  textColorPrimary: '#FFFFFF',
-  schemeColorLighter: '#EC658B',
-  hoverColorLighter: '#EA527D',
-  textColorSecondary: '#FFFFFF',
-  textColorTertiary: '#000000',
-  schemeColorLightest: '#FAD8E2'
+  schemeColorDarkest: '#e83f6f',
+  schemeColorDark: '#ec658b',
+  schemeColorLight: '#f18ba8',
+  schemeColorLightest: '#fad8e2',
+  hoverColorDark: '#d03863',
+  hoverColorLight: '#ea527d',
+  hoverColorLightest: '#f5b2c5',
+  textColorPrimary: '#fff',
+  textColorSecondary: '#fff',
+  textColorTertiary: '#451221',
+  borderColor: '#b93258',
 }
 
 export const BLUE = {
-  schemeColor: '#2274A5',
-  hoverColor: '#1E6894',
-  borderColor: '#1B5C84',
-  textColorPrimary: '#FFFFFF',
-  schemeColorLighter: '#4E8FB7',
-  hoverColorLighter: '#3881AE',
-  textColorSecondary: '#FFFFFF',
-  textColorTertiary: '#000000',
-  schemeColorLightest: '#D2E3ED'
+  schemeColorDarkest: '#2274a5',
+  schemeColorDark: '#4e8fb7',
+  schemeColorLight: '#7aabc9',
+  schemeColorLightest: '#d2e3ed',
+  hoverColorDark: '#1e6894',
+  hoverColorLight: '#3881ae',
+  hoverColorLightest: '#bcd5e4',
+  textColorPrimary: '#fff',
+  textColorSecondary: '#fff',
+  textColorTertiary: '#0d2e42',
+  borderColor: '#1b5c84'
 }
 
 export const GREEN = {
-  schemeColor: '#00A323',
-  hoverColor: '#00921F',
-  borderColor: '#00821C',
-  textColorPrimary: '#FFFFFF',
-  schemeColorLighter: '#32B54E',
-  hoverColorLighter: '#19AC38',
-  textColorSecondary: '#FFFFFF',
-  textColorTertiary: '#000000',
-  schemeColorLightest: '#CCECD3'
+  schemeColorDarkest: '#00a323',
+  schemeColorDark: '#32b54e',
+  schemeColorLight: '#66c77b',
+  schemeColorLightest: '#ccecd3',
+  hoverColorDark: '#00921f',
+  hoverColorLight: '#19ac38',
+  hoverColorLightest: '#b2e3bd',
+  textColorPrimary: '#fff',
+  textColorSecondary: '#fff',
+  textColorTertiary: '#00410e',
+  borderColor: '#00821c'
 }
 
 export const AQUA = {
-  schemeColor: '#20E2E9',
-  hoverColor: '#1CCBD1',
-  borderColor: '#19B4BA',
-  textColorPrimary: '#000000',
-  schemeColorLighter: '#62EAEF',
-  hoverColorLighter: '#4CE7ED',
-  textColorSecondary: '#000000',
-  textColorTertiary: '#000000',
-  schemeColorLightest: '#D2F9FA'
+  schemeColorDarkest: '#20e2e9',
+  schemeColorDark: '#62eaef',
+  schemeColorLight: '#8ff0f4',
+  schemeColorLightest: '#d2f9fa',
+  hoverColorDark: '#11cbd1',
+  hoverColorLight: '#4ce7ed',
+  hoverColorLightest: '#bcf6f8',
+  textColorPrimary: '#094345',
+  textColorSecondary: '#094345',
+  textColorTertiary: '#094345',
+  borderColor: '#19b4ba'
 }
 
 const colorSchemes = [


### PR DESCRIPTION
## Context

[**Refine colour schemes**](https://trello.com/c/BgaHBi6v/61-refine-colour-schemes)

Colour schemes needed to be expanded with better colour names and more colours within each scheme.

## Changes

* Standardise colour names
* Add more colours to each scheme
* Incorporate changes throughout application

## Considerations

I tried considered making the colours within the shopping list components contrast more, but I didn't end up liking the results so I kept them the same. I've updated components including the `ShoppingListItemEditForm`, `Loading`, and `ShoppingListCreateForm` components, which use colour schemes outside of the `ColorContext`, as well as the components that do use the context.

## Manual Test Cases

Make sure that everything has a colour and that the hover colour is congruent with the main colour scheme on all the components.

## Screenshots and GIFs

![issue-61](https://user-images.githubusercontent.com/5115928/125252815-21d3be80-e33c-11eb-80bd-941b8d04820a.png)

