### PR TITLE
Update 'master' language to use 'aggregate'/'All Items' instead

### DIFF
--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -240,7 +240,7 @@ The value of the `ShoppingListProvider` includes the following.
 
 #### `shoppingLists`
 
-The array of all the user's shopping lists, with the master list first.
+The array of all the user's shopping lists, with the aggregate list first.
 
 #### `shoppingListLoadingState`
 
@@ -248,7 +248,7 @@ Whether the `shoppingLists` are 'loading' (waiting for the API call to resolve),
 
 #### `performShoppingListCreate`
 
-A function that creates a shopping list for the authenticated user and updates the master list to reflect the change, also encompassing error handling logic. The function takes 3 arguments:
+A function that creates a shopping list for the authenticated user and updates the aggregate list to reflect the change, also encompassing error handling logic. The function takes 3 arguments:
 
 * `title`: the title of the new list. Must be unique, contain only alphanumeric characters and spaces, and cannot be any form of "Master". Will be reformatted on the backend to use title casing
 * `success`: an optional success callback that can be used for handling state within the component that calls the function
@@ -273,7 +273,7 @@ A function that deletes the list specified through the API, also encompassing er
 
 #### `performShoppingListItemCreate`
 
-A function that creates a shopping list item on the list specified (or combines the new attributes given with an existing item with the same description), also encompassing error handling logic. This will also cause the master list to update. The function takes four arguments:
+A function that creates a shopping list item on the list specified (or combines the new attributes given with an existing item with the same description), also encompassing error handling logic. This will also cause the aggregate list to update. The function takes four arguments:
 
 * `listId`: the ID of the shopping list the item should be added to
 * `attrs`: The attributes the item should be created with. Attributes can include:
@@ -285,7 +285,7 @@ A function that creates a shopping list item on the list specified (or combines 
 
 #### `performShoppingListItemUpdate`
 
-A function that updates the specified shopping list item, also encompassing error handling logic. This will also cause the master list to update. The function takes four arguments:
+A function that updates the specified shopping list item, also encompassing error handling logic. This will also cause the aggregate list to update. The function takes four arguments:
 
 * `itemId`: the ID of the item to be updated
 * `attrs`: the attributes to be updated on the list item. Cannot update item `description`. Attributes can include:
@@ -297,7 +297,7 @@ A function that updates the specified shopping list item, also encompassing erro
 
 #### `performShoppingListItemDestroy`
 
-A function that destroys the specified shopping list item, also encompassing error handling logic. This also updates the master list to reflect the change. The function takes three arguments:
+A function that destroys the specified shopping list item, also encompassing error handling logic. This also updates the aggregate list to reflect the change. The function takes three arguments:
 
 * `itemId`: the ID of the item to be destroyed
 * `success`: an optional success callback that can be used for handling state within the component that calls the function

--- a/src/components/navigationMosaic/navigationMosaic.js
+++ b/src/components/navigationMosaic/navigationMosaic.js
@@ -26,15 +26,17 @@ NavigationMosaic.propTypes = {
       children: PropTypes.node.isRequired,
       key: PropTypes.string.isRequired,
       colorScheme: PropTypes.shape({
-        schemeColor: PropTypes.string.isRequired,
-        hoverColor: PropTypes.string.isRequired,
+        schemeColorDarkest: PropTypes.string.isRequired,
+        schemeColorDark: PropTypes.string.isRequired,
+        schemeColorLight: PropTypes.string.isRequired,
+        schemeColorLightest: PropTypes.string.isRequired,
+        hoverColorDark: PropTypes.string.isRequired,
+        hoverColorLight: PropTypes.string.isRequired,
+        hoverColorLightest: PropTypes.string.isRequired,
         textColorPrimary: PropTypes.string.isRequired,
-        borderColor: PropTypes.string,
-        schemeColorLighter: PropTypes.string,
-        hoverColorLighter: PropTypes.string,
-        schemeColorLightest: PropTypes.string,
         textColorSecondary: PropTypes.string,
-        textColorTertiary: PropTypes.string
+        textColorTertiary: PropTypes.string,
+        borderColor: PropTypes.string
       }).isRequired
     })
   ).isRequired

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -18,8 +18,9 @@ const isValid = str => (
   // whitespace (which will be stripped before it is saved in the DB).
   // Any other characters (including non-space whitespace characters
   // that are not leading or trailing) will cause a validation error
-  // on the backend. The title of a regular list may also not be "Master".
-  !!str && str.match(/^\s*[a-z0-9 ]*\s*$/i) && str.match(/^\s*[a-z0-9 ]*\s*$/i)[0] === str && str !== 'Master'
+  // on the backend. The title of a regular list may also not be "All
+  // Items".
+  !!str && str.match(/^\s*[a-z0-9 ]*\s*$/i) && str.match(/^\s*[a-z0-9 ]*\s*$/i)[0] === str && str.toLowerCase() !== 'all items'
 )
 
 const ShoppingList = ({ canEdit = true, listId, title}) => {

--- a/src/components/shoppingList/shoppingList.stories.js
+++ b/src/components/shoppingList/shoppingList.stories.js
@@ -24,7 +24,7 @@ const regularListItems = [
   }
 ]
 
-const masterListItems = [
+const aggregateListItems = [
   {
     id: 3,
     list_id: 1,
@@ -45,15 +45,15 @@ const shoppingLists = [
   {
     id: 1,
     user_id: 24,
-    title: 'Master',
-    master: true,
-    list_items: masterListItems
+    title: 'All Items',
+    aggregate: true,
+    list_items: aggregateListItems
   },
   {
     id: 2,
     user_id: 24,
     title: 'My List 1',
-    master: false,
+    aggregate: false,
     list_items: regularListItems
   }
 ]
@@ -82,14 +82,14 @@ Default.parameters = {
           [
             {
               id: 1,
-              title: 'Master',
-              master: true,
-              list_items: masterListItems
+              title: 'All Items',
+              aggregate: true,
+              list_items: aggregateListItems
             },
             {
               id: 2,
               title: 'My List 1',
-              master: false,
+              aggregate: false,
               list_items: regularListItems
             }
           ]
@@ -99,16 +99,16 @@ Default.parameters = {
     rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
       const itemId = Number(req.params.id)
       const regularItem = regularListItems.find(item => item.id === itemId)
-      const masterListItem = masterListItems.find(item => item.description === regularItem.description)
+      const aggregateListItem = aggregateListItems.find(item => item.description === regularItem.description)
       const newQty = req.body.shopping_list_item.quantity
 
       const returnData = [
         {
-          id: masterListItem.id,
+          id: aggregateListItem.id,
           list_id: 1,
-          description: masterListItem.description,
+          description: aggregateListItem.description,
           quantity: newQty,
-          notes: masterListItem.notes
+          notes: aggregateListItem.notes
         },
         {
           id: itemId,
@@ -131,7 +131,7 @@ export const NotEditable = () => (
     <ColorProvider colorScheme={PINK}>
       <ShoppingListProvider overrideValue={{ shoppingLists }}>
         <ShoppingList
-          title='Master'
+          title='All Items'
           listId={1}
           canEdit={false}
         />
@@ -148,14 +148,14 @@ NotEditable.parameters = {
         ctx.json([
           {
             id: 1,
-            title: 'Master',
-            master: true,
-            list_items: masterListItems
+            title: 'All Items',
+            aggregate: true,
+            list_items: aggregateListItems
           },
           {
             id: 2,
             title: 'My List 1',
-            master: false,
+            aggregate: false,
             list_items: regularListItems
           }
         ])
@@ -167,17 +167,17 @@ NotEditable.parameters = {
 const emptyShoppingLists = [
   {
     id: 1,
-    title: 'Master',
+    title: 'All Items',
     user_id: 24,
     list_items: [],
-    master: true
+    aggregate: true
   },
   {
     id: 2,
     title: 'Severin Manor',
     user_id: 24,
     list_items: [],
-    master: false
+    aggregate: false
   }
 ]
 
@@ -195,12 +195,12 @@ export const EmptyList = () => (
   </AppProvider>
 )
 
-export const EmptyMasterList = () => (
+export const EmptyAggregateList = () => (
   <AppProvider overrideValue={{ token: 'xxxxxx', setShouldRedirectTo: () => null }}>
     <ColorProvider colorScheme={PINK}>
       <ShoppingListProvider overrideValue={{ shoppingLists: emptyShoppingLists }}>
         <ShoppingList
-          title='Master'
+          title='All Items'
           listId={1}
           canEdit={false}
         />

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.stories.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.stories.js
@@ -32,14 +32,14 @@ const listItems = [
 const shoppingLists = [
   {
     id: 1,
-    title: 'Master',
-    master: true,
+    title: 'All Items',
+    aggregate: true,
     list_items: listItems
   },
   {
     id: 1,
     title: 'My List 2',
-    master: false,
+    aggregate: false,
     list_items: listItems
   }
 ]

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -102,7 +102,7 @@ const ShoppingListItem = ({
   }
 
   const destroyItem = () => {
-    const confirmed = window.confirm("Destroy shopping list item? Your master list will be updated to reflect the change. This action cannot be undone.")
+    const confirmed = window.confirm("Destroy shopping list item? Your aggregate list will be updated to reflect the change. This action cannot be undone.")
 
     if (confirmed) {
       performShoppingListItemDestroy(itemId, () => { mountedRef.current = false })

--- a/src/components/shoppingListItem/storyData.js
+++ b/src/components/shoppingListItem/storyData.js
@@ -2,8 +2,8 @@ export const shoppingLists = [
   {
     id: 1,
     user_id: 24,
-    master: true,
-    title: 'Master',
+    aggregate: true,
+    title: 'All Items',
     list_items: [
       {
         id: 2,
@@ -17,7 +17,7 @@ export const shoppingLists = [
   {
     id: 2,
     user_id: 24,
-    master: false,
+    aggregate: false,
     title: 'Heljarchen Hall',
     list_items: [
       {

--- a/src/components/shoppingListItemEditForm/storyData.js
+++ b/src/components/shoppingListItemEditForm/storyData.js
@@ -17,8 +17,8 @@ export const listItemData = {
 export const shoppingLists = [
   {
     id: 1,
-    title: 'Master',
-    master: true,
+    title: 'All Items',
+    aggregate: true,
     list_items: [
       {
         ...listItemData,
@@ -30,7 +30,7 @@ export const shoppingLists = [
   {
     id: 2,
     title: 'Proudspire Manor',
-    master: false,
+    aggregate: false,
     list_items: [listItemData]
   }
 ]

--- a/src/components/shoppingListPageContent/shoppingListPageContent.js
+++ b/src/components/shoppingListPageContent/shoppingListPageContent.js
@@ -27,7 +27,7 @@ const ShoppingListPageContent = () => {
   if (listsLoadedAndNotEmpty) {
     return(
       <>
-        {shoppingLists.map(({ id, title, master }, index) => {
+        {shoppingLists.map(({ id, title, aggregate }, index) => {
           // If there are more lists than colour schemes, cycle through the colour schemes
           const colorSchemesIndex = index < colorSchemes.length ? index : index % colorSchemes.length
           const colorScheme = colorSchemes[colorSchemesIndex]
@@ -37,7 +37,7 @@ const ShoppingListPageContent = () => {
             <ColorProvider key={listKey} colorScheme={colorScheme}>
               <div className={styles.shoppingList}>
                 <ShoppingList
-                  canEdit={!master}
+                  canEdit={!aggregate}
                   listId={id}
                   title={title}
                 />

--- a/src/components/shoppingListPageContent/shoppingListPageContent.stories.js
+++ b/src/components/shoppingListPageContent/shoppingListPageContent.stories.js
@@ -11,7 +11,7 @@ import {
   removeOrAdjustItemOnItemDestroy,
   addOrCombineListItem,
   findListByListItem,
-  adjustMasterListItem
+  adjustAggregateListItem
 } from './storyData'
 import ShoppingListPageContent from './shoppingListPageContent'
 
@@ -43,16 +43,16 @@ HappyPath.parameters = {
       const regularList = shoppingLists.find(list => list.id === listId)
       const items = regularList.list_items
       
-      const newMasterList = removeOrAdjustItemsOnListDestroy(shoppingLists[0], items)
+      const newAggregateList = removeOrAdjustItemsOnListDestroy(shoppingLists[0], items)
 
-      if (newMasterList === null) {
+      if (newAggregateList === null) {
         return res(
           ctx.status(204)
           )
         } else {
         return res(
           ctx.status(200),
-          ctx.json(newMasterList)
+          ctx.json(newAggregateList)
         )
       }
     }),
@@ -60,11 +60,11 @@ HappyPath.parameters = {
       const listId = Number(req.params.shopping_list_id)
       const list = shoppingLists.find(shoppingList => shoppingList.id === listId)
       const regularListItem = addOrCombineListItem(list, req.body.shopping_list_item)
-      const masterListItem = addOrCombineListItem(shoppingLists[0], req.body.shopping_list_item)
+      const aggregateListItem = addOrCombineListItem(shoppingLists[0], req.body.shopping_list_item)
 
       return res(
         ctx.status(200),
-        ctx.json([masterListItem, regularListItem])
+        ctx.json([aggregateListItem, regularListItem])
       )
     }),
     rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
@@ -73,25 +73,25 @@ HappyPath.parameters = {
       const existingItem = list.list_items.find(item => item.id === itemId)
       const newItem = { ...existingItem, ...req.body.shopping_list_item }
       const deltaQuantity = newItem.quantity - existingItem.quantity
-      const masterListItem = shoppingLists[0].list_items.find(item => item.description === existingItem.description)
-      const newMasterListItem = adjustMasterListItem(masterListItem, deltaQuantity, existingItem.notes, newItem.notes)
+      const aggregateListItem = shoppingLists[0].list_items.find(item => item.description === existingItem.description)
+      const newAggregateListItem = adjustAggregateListItem(aggregateListItem, deltaQuantity, existingItem.notes, newItem.notes)
 
       return res(
         ctx.status(200),
-        ctx.json([newMasterListItem, newItem])
+        ctx.json([newAggregateListItem, newItem])
       )
     }),
     rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
       const itemId = Number(req.params.id)
       const list = findListByListItem(shoppingLists, itemId)
       const item = list.list_items.find(listItem => listItem.id === itemId)
-      const masterListItem = shoppingLists[0].list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
-      removeOrAdjustItemOnItemDestroy(masterListItem, item)
+      const aggregateListItem = shoppingLists[0].list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
+      removeOrAdjustItemOnItemDestroy(aggregateListItem, item)
 
-      if (masterListItem) {
+      if (aggregateListItem) {
         return res(
           ctx.status(200),
-          ctx.json(masterListItem)
+          ctx.json(aggregateListItem)
         )
       } else {
         return res(

--- a/src/components/shoppingListPageContent/storyData.js
+++ b/src/components/shoppingListPageContent/storyData.js
@@ -12,8 +12,8 @@ export const shoppingLists = [
   {
     id: 1,
     user_id: 24,
-    master: true,
-    title: 'Master',
+    aggregate: true,
+    title: 'All Items',
     list_items: [
       {
         id: 2,
@@ -32,7 +32,7 @@ export const shoppingLists = [
       {
         id: 6,
         list_id: 1,
-        description: "Item there's only one of on the master list",
+        description: "Item there's only one of on the aggregate list",
         quantity: 1,
         notes: 'notes1'
       }
@@ -41,7 +41,7 @@ export const shoppingLists = [
   {
     id: 2,
     user_id: 24,
-    master: false,
+    aggregate: false,
     title: 'Heljarchen Hall',
     list_items: [
       {
@@ -61,7 +61,7 @@ export const shoppingLists = [
       {
         id: 4,
         list_id: 2,
-        description: "Item there's only one of on the master list",
+        description: "Item there's only one of on the aggregate list",
         quantity: 1,
         notes: 'notes1'
       }
@@ -70,7 +70,7 @@ export const shoppingLists = [
   {
     id: 3,
     user_id: 24,
-    master: false,
+    aggregate: false,
     title: 'Lakeview Manor',
     list_items: [
       {
@@ -86,7 +86,7 @@ export const shoppingLists = [
 
 export const shoppingListUpdateData = {
   user_id: 24,
-  master: false,
+  aggregate: false,
   list_items: [
     {
       id: 1,
@@ -105,29 +105,29 @@ export const shoppingListUpdateData = {
   ]
 }
 
-export const removeOrAdjustItemsOnListDestroy = (masterList, items) => {
-  const newMasterListItems = []
+export const removeOrAdjustItemsOnListDestroy = (aggregateList, items) => {
+  const newAggregateListItems = []
 
   for (const item of items) {
-    const existingMasterListItem = masterList.list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
-    const masterListItem = removeOrAdjustItemOnItemDestroy(existingMasterListItem, item)
+    const existingAggregateListItem = aggregateList.list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
+    const aggregateListItem = removeOrAdjustItemOnItemDestroy(existingAggregateListItem, item)
 
-    if (!masterListItem) continue // it should be removed from the array
+    if (!aggregateListItem) continue // it should be removed from the array
 
-    newMasterListItems.push(masterListItem)
+    newAggregateListItems.push(aggregateListItem)
   }
 
-  masterList.list_items = newMasterListItems
-  return newMasterListItems.length === 0 ? null : masterList
+  aggregateList.list_items = newAggregateListItems
+  return newAggregateListItems.length === 0 ? null : aggregateList
 }
 
-export const removeOrAdjustItemOnItemDestroy = (masterListItem, destroyedItem) => {
-  if (masterListItem.quantity === destroyedItem.quantity) return null
+export const removeOrAdjustItemOnItemDestroy = (aggregateListItem, destroyedItem) => {
+  if (aggregateListItem.quantity === destroyedItem.quantity) return null
 
-  masterListItem.quantity -= destroyedItem.quantity
-  if (masterListItem.notes) masterListItem.notes.replace(destroyedItem.notes, '').replace(/^ --/, '').replace(/ -- $/, '')
+  aggregateListItem.quantity -= destroyedItem.quantity
+  if (aggregateListItem.notes) aggregateListItem.notes.replace(destroyedItem.notes, '').replace(/^ --/, '').replace(/ -- $/, '')
 
-  return masterListItem
+  return aggregateListItem
 }
 
 const combineListItems = (existingItem, newItem) => {
@@ -156,16 +156,16 @@ export const findListByListItem = (lists, itemId) => {
   return null
 }
 
-export const adjustMasterListItem = (masterListItem, deltaQuantity, oldNotes, newNotes) => {
-  masterListItem.quantity = masterListItem.quantity + deltaQuantity
+export const adjustAggregateListItem = (aggregateListItem, deltaQuantity, oldNotes, newNotes) => {
+  aggregateListItem.quantity = aggregateListItem.quantity + deltaQuantity
 
   if (oldNotes !== newNotes) {
-    if (masterListItem.notes) {
-      masterListItem.notes.replace(oldNotes, newNotes)
+    if (aggregateListItem.notes) {
+      aggregateListItem.notes.replace(oldNotes, newNotes)
     } else {
-      masterListItem.notes = newNotes
+      aggregateListItem.notes = newNotes
     }
   }
 
-  return masterListItem
+  return aggregateListItem
 }

--- a/src/pages/shoppingListPage/shoppingListPage.stories.js
+++ b/src/pages/shoppingListPage/shoppingListPage.stories.js
@@ -8,7 +8,7 @@ import {
   emptyShoppingLists,
   shoppingLists,
   findListByListItem,
-  adjustMasterListItem,
+  adjustAggregateListItem,
   removeOrAdjustItemsOnListDestroy,
   removeOrAdjustItemOnItemDestroy
 } from './storyData'
@@ -43,7 +43,7 @@ HappyPath.parameters = {
   msw: [
     rest.post(`${backendBaseUri}/shopping_lists`, (req, res, ctx) => {
       const title = req.body.shopping_list.title || 'My List 3'
-      const returnData = [{ id: 32, user_id: 24, title: title, master: false, list_items: [] }]
+      const returnData = [{ id: 32, user_id: 24, title: title, aggregate: false, list_items: [] }]
 
       return res(
         ctx.status(201),
@@ -53,7 +53,7 @@ HappyPath.parameters = {
     rest.patch(`${backendBaseUri}/shopping_lists/:id`, (req, res, ctx) => {
       const title = req.body.shopping_list.title || 'My List 1'
       const listId = Number(req.params.id)
-      const returnData = { id: listId, user_id: 24, title: title, master: false, list_items: []}
+      const returnData = { id: listId, user_id: 24, title: title, aggregate: false, list_items: []}
 
       return res(
         ctx.status(200),
@@ -65,16 +65,16 @@ HappyPath.parameters = {
       const regularList = shoppingLists.find(list => list.id === listId)
       const items = regularList.list_items
 
-      const newMasterList = removeOrAdjustItemsOnListDestroy(shoppingLists[0], items)
+      const newAggregateList = removeOrAdjustItemsOnListDestroy(shoppingLists[0], items)
 
-      if (newMasterList === null) {
+      if (newAggregateList === null) {
         return res(
           ctx.status(204)
         )
       } else {
         return res(
           ctx.status(200),
-          ctx.json(newMasterList)
+          ctx.json(newAggregateList)
         )
       }
     }),
@@ -113,25 +113,25 @@ HappyPath.parameters = {
       const existingItem = list.list_items.find(item => item.id === itemId)
       const newItem = { ...existingItem, ...req.body.shopping_list_item }
       const deltaQuantity = newItem.quantity - existingItem.quantity
-      const masterListItem = shoppingLists[0].list_items.find(item => item.description === existingItem.description)
-      adjustMasterListItem(masterListItem, deltaQuantity, existingItem.notes, newItem.notes)
+      const aggregateListItem = shoppingLists[0].list_items.find(item => item.description === existingItem.description)
+      adjustAggregateListItem(aggregateListItem, deltaQuantity, existingItem.notes, newItem.notes)
 
       return res(
         ctx.status(200),
-        ctx.json([masterListItem, newItem])
+        ctx.json([aggregateListItem, newItem])
       )
     }),
     rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
       const itemId = Number(req.params.id)
       const list = findListByListItem(shoppingLists, itemId)
       const item = list.list_items.find(listItem => listItem.id === itemId)
-      const masterListItem = shoppingLists[0].list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
-      removeOrAdjustItemOnItemDestroy(masterListItem, item)
+      const aggregateListItem = shoppingLists[0].list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
+      removeOrAdjustItemOnItemDestroy(aggregateListItem, item)
 
-      if (masterListItem) {
+      if (aggregateListItem) {
         return res(
           ctx.status(200),
-          ctx.json(masterListItem)
+          ctx.json(aggregateListItem)
         )
       } else {
         return res(
@@ -167,7 +167,7 @@ ResourceNotFound.parameters = {
     }),
     rest.post(`${backendBaseUri}/shopping_lists`, (req, res, ctx) => {
       const title = req.body.shopping_list.title || 'My List 3'
-      const returnData = [{ id: 32, user_id: 24, title: title, master: false, list_items: [] }]
+      const returnData = [{ id: 32, user_id: 24, title: title, aggregate: false, list_items: [] }]
 
       return res(
         ctx.status(201),
@@ -235,10 +235,10 @@ UnprocessableEntity.parameters = {
       return res(
         ctx.status(200),
         ctx.json({
-          master_list: {
+          aggregate_list: {
             id: 93,
-            title: 'Master',
-            master: true,
+            title: 'All Items',
+            aggregate: true,
             user_id: 24,
             list_items: []
           }
@@ -261,13 +261,13 @@ UnprocessableEntity.parameters = {
       const itemId = Number(req.params.id)
       const list = findListByListItem(shoppingLists, itemId)
       const item = list.list_items.find(listItem => listItem.id === itemId)
-      const masterListItem = shoppingLists[0].list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
-      removeOrAdjustItemOnItemDestroy(masterListItem, item)
+      const aggregateListItem = shoppingLists[0].list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
+      removeOrAdjustItemOnItemDestroy(aggregateListItem, item)
 
-      if (masterListItem) {
+      if (aggregateListItem) {
         return res(
           ctx.status(200),
-          ctx.json(masterListItem)
+          ctx.json(aggregateListItem)
         )
       } else {
         return res(
@@ -297,8 +297,8 @@ Empty.parameters = {
     rest.post(`${backendBaseUri}/shopping_lists`, (req, res, ctx) => {
       const title = req.body.shopping_list.title || 'My List 3'
       const returnData = [
-        { id: 32, user_id: 24, title: 'Master', master: true, list_items: [] },
-        { id: 33, user_id: 24, title: title, master: false, list_items: [] }
+        { id: 32, user_id: 24, title: 'All Items', aggregate: true, list_items: [] },
+        { id: 33, user_id: 24, title: title, aggregate: false, list_items: [] }
       ]
 
       return res(
@@ -309,7 +309,7 @@ Empty.parameters = {
     rest.patch(`${backendBaseUri}/shopping_lists/:id`, (req, res, ctx) => {
       const listId = Number(req.params.id)
       const title = req.body.shopping_list.title || 'My List 2'
-      const returnData = { id: listId, user_id: 24, title, master: false, list_items: [] }
+      const returnData = { id: listId, user_id: 24, title, aggregate: false, list_items: [] }
 
       return res(
         ctx.status(200),

--- a/src/pages/shoppingListPage/storyData.js
+++ b/src/pages/shoppingListPage/storyData.js
@@ -12,8 +12,8 @@ export const shoppingLists = [
   {
     id: 1,
     user_id: 24,
-    master: true,
-    title: 'Master',
+    aggregate: true,
+    title: 'All Items',
     list_items: [
       {
         id: 2,
@@ -34,7 +34,7 @@ export const shoppingLists = [
   {
     id: 2,
     user_id: 24,
-    master: false,
+    aggregate: false,
     title: 'Heljarchen Hall',
     list_items: [
       {
@@ -56,7 +56,7 @@ export const shoppingLists = [
   {
     id: 3,
     user_id: 24,
-    master: false,
+    aggregate: false,
     title: 'Lakeview Manor',
     list_items: [
       {
@@ -79,41 +79,41 @@ export const findListByListItem = (lists, itemId) => {
   return null
 }
 
-export const adjustMasterListItem = (masterListItem, deltaQuantity, oldNotes, newNotes) => {
-  masterListItem.quantity = masterListItem.quantity + deltaQuantity
+export const adjustAggregateListItem = (aggregateListItem, deltaQuantity, oldNotes, newNotes) => {
+  aggregateListItem.quantity = aggregateListItem.quantity + deltaQuantity
 
   if (oldNotes !== newNotes) {
-    if (masterListItem.notes) {
-      masterListItem.notes.replace(oldNotes, newNotes)
+    if (aggregateListItem.notes) {
+      aggregateListItem.notes.replace(oldNotes, newNotes)
     } else {
-      masterListItem.notes = newNotes
+      aggregateListItem.notes = newNotes
     }
   }
 
-  return masterListItem
+  return aggregateListItem
 }
 
-export const removeOrAdjustItemsOnListDestroy = (masterList, items) => {
-  const newMasterListItems = []
+export const removeOrAdjustItemsOnListDestroy = (aggregateList, items) => {
+  const newAggregateListItems = []
 
   for (const item of items) {
-    const existingMasterListItem = masterList.list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
-    const masterListItem = removeOrAdjustItemOnItemDestroy(existingMasterListItem, item)
+    const existingAggregateListItem = aggregateList.list_items.find(listItem => listItem.description.toLowerCase() === item.description.toLowerCase())
+    const aggregateListItem = removeOrAdjustItemOnItemDestroy(existingAggregateListItem, item)
 
-    if (!masterListItem) continue // it should be removed from the array
+    if (!aggregateListItem) continue // it should be removed from the array
 
-    newMasterListItems.push(masterListItem)
+    newAggregateListItems.push(aggregateListItem)
   }
 
-  masterList.list_items = newMasterListItems
-  return newMasterListItems.length === 0 ? null : masterList
+  aggregateList.list_items = newAggregateListItems
+  return newAggregateListItems.length === 0 ? null : aggregateList
 }
 
-export const removeOrAdjustItemOnItemDestroy = (masterListItem, destroyedItem) => {
-  if (masterListItem.quantity === destroyedItem.quantity) return null
+export const removeOrAdjustItemOnItemDestroy = (aggregateListItem, destroyedItem) => {
+  if (aggregateListItem.quantity === destroyedItem.quantity) return null
 
-  masterListItem.quantity -= destroyedItem.quantity
-  if (masterListItem.notes) masterListItem.notes.replace(destroyedItem.notes, '').replace(/^ --/, '').replace(/ -- $/, '')
+  aggregateListItem.quantity -= destroyedItem.quantity
+  if (aggregateListItem.notes) aggregateListItem.notes.replace(destroyedItem.notes, '').replace(/^ --/, '').replace(/ -- $/, '')
 
-  return masterListItem
+  return aggregateListItem
 }

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -114,7 +114,7 @@ export const updateShoppingList = (token, listId, attrs) => {
       // JSON to handle the error
       if (resp.status === 401) throw new AuthorizationError()
       if (resp.status === 404) throw new NotFoundError('Shopping list not found. Try refreshing the page to resolve this issue.')
-      if (resp.status === 405) throw new MethodNotAllowedError('Master lists are managed automatically and cannot be updated manually.')
+      if (resp.status === 405) throw new MethodNotAllowedError('Aggregate lists are managed automatically and cannot be updated manually.')
       return resp
     })
   )
@@ -132,7 +132,7 @@ export const destroyShoppingList = (token, listId) => {
     .then(resp => {
       if (resp.status === 401) throw new AuthorizationError()
       if (resp.status === 404) throw new NotFoundError('Shopping list not found. Try refreshing the page to resolve this issue.')
-      if (resp.status === 405) throw new MethodNotAllowedError('Master lists are managed automatically and cannot be deleted manually.')
+      if (resp.status === 405) throw new MethodNotAllowedError('Aggregate lists are managed automatically and cannot be deleted manually.')
       return resp
     })
   )


### PR DESCRIPTION
## Context

[**Change name of master shopping list to main shopping list**](https://trello.com/c/kdN0AKtD/65-change-name-of-master-shopping-list-to-main-shopping-list)

Front end changes for danascheider/skyrim_inventory_management#28

We've changed the language so instead of master shopping lists being called master lists and titled "Master", they are now called "aggregate" lists and titled "All Items". The front end now needs to reflect these changes.

## Changes

* Change `master` language to `aggregate`
* Change title of aggregate lists in stories to "All Items"
* Update title validity check so regular lists can be titled "master" and not "all items"

## Considerations

The card suggested the use of the term "main" list, but I felt "aggregate" better captured the function of these lists. I talked about that more on the back-end PR.

## Manual Test Cases

Make sure none of the shopping list functionality is broken because of this, either on the running app or in Storybook.

## Screenshots and GIFs

This should not result in visible changes to the UI.