### PR TITLE
Handle 500 errors from the back end

### DIFF
--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -74,12 +74,20 @@ const AppProvider = ({ children, overrideValue = {} }) => {
       fetchUserProfile(cookies[sessionCookieName])
         .then(response => response.json())
         .then(data => {
-          setProfileData(data)
-          if (!overrideValue.profileLoadState) setProfileLoadState(DONE)
+          if (data.errors) {
+            throw new Error('Internal Server Error: ', data.errors[0])
+          } else {
+            setProfileData(data)
+            if (!overrideValue.profileLoadState) setProfileLoadState(DONE)
+          }
         })
         .catch(error => {
           if (process.env.NODE_ENV !== 'production') console.error('Error returned while fetching profile data: ', error.message)
 
+          // I feel like this might not be the right behaviour if the error was a 500,
+          // but I also can't think of a case where an error like this would occur and
+          // not be a 401, given the user profile will be created during the authorization
+          // step if it doesn't exist already.
           logOutAndRedirect()
         })
     } else if (!cookies[sessionCookieName] && !isStorybook()) {

--- a/src/pages/homePage/homePage.js
+++ b/src/pages/homePage/homePage.js
@@ -15,10 +15,18 @@ const HomePage = () => {
   const verifyLogin = () => {
     if (token && !isStorybook()) {
       authorize(token)
-        .then(() => {
-          setShouldRedirectTo(paths.dashboard.main)
+        .then(resp => resp.status === 500 ? resp.json() : null)
+        .then(data => {
+          if (data) {
+            throw new Error('Internal Server Error: ', data.errors[0])
+          } else {
+            setShouldRedirectTo(paths.dashboard.main)
+            mountedRef.current = false
+          }
         })
-        .catch(() => {
+        .catch(err => {
+          if (process.env.NODE_ENV !== 'production') console.error(err.message)
+
           logOutWithGoogle(() => removeSessionCookie())
         })
     }

--- a/src/pages/loginPage/loginPage.js
+++ b/src/pages/loginPage/loginPage.js
@@ -22,7 +22,7 @@ const LoginPage = () => {
   const successCallback = (resp) => {
     const { tokenId } = resp
 
-    if (token !== tokenId) {
+    if (tokenId) {
       setSessionCookie(tokenId)
       setShouldRedirectTo(paths.dashboard.main)
       mountedRef.current = false


### PR DESCRIPTION
## Context

[**Implement 500 errors**](https://trello.com/c/8cbmEK0m/73-implement-500-errors)

I've just implemented a [more organised handling](https://github.com/danascheider/skyrim_inventory_management/pull/29) of internal server errors on the backend and it seemed like a good time to handle those errors on the front end too.

## Changes

* Handle 500 errors on all API calls

## Considerations

I don't like that the 500 error handling on the dashboard/user profile leads to the user being logged out since it could theoretically happen right after they log in, but I also don't see a case where profile info would fail to be fetched and we would want them to stay logged in.

## Manual Test Cases

This is a tricky one to test since it's by definition handling errors that we don't expect to ever happen, so I'll explain how I tested it in dev. I walked through all the API calls in the app. For each API call, I went to the controller service that handled that API call and raised a `StandardError` with a message at the beginning of its `#perform` method. Then, on the front end, I did whatever action would cause that API call to happen and observed the error handling. At this point they all are handled correctly.