### PR TITLE
Straighten out dependencies in useEffect hooks

### DIFF
--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -67,15 +67,6 @@ const AppProvider = ({ children, overrideValue = {} }) => {
     })
   }, [cookies, removeSessionCookie, onAuthenticatedPage, setShouldRedirectTo])
 
-  // const logOutAndRedirect = () => {
-  //   logOutWithGoogle(() => {
-  //     cookies[sessionCookieName] && removeSessionCookie()
-  //     if (onAuthenticatedPage) {
-  //       setShouldRedirectTo(paths.login)
-  //     }
-  //   })
-  // }
-
   const fetchProfileData = () => {
     if (shouldFetchProfileData) {
       fetchUserProfile(cookies[sessionCookieName])

--- a/src/pages/homePage/homePage.js
+++ b/src/pages/homePage/homePage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { authorize } from '../../utils/simApi'
 import isStorybook from '../../utils/isStorybook'
@@ -12,7 +12,7 @@ const HomePage = () => {
 
   const mountedRef = useRef(true)
 
-  const verifyLogin = () => {
+  const verifyLogin = useCallback(() => {
     if (token && !isStorybook()) {
       authorize(token)
         .then(resp => resp.status === 500 ? resp.json() : null)
@@ -30,12 +30,12 @@ const HomePage = () => {
           logOutWithGoogle(() => removeSessionCookie())
         })
     }
-  }
+  }, [token, removeSessionCookie, setShouldRedirectTo])
 
   useEffect(() => {
     verifyLogin()
     return () => mountedRef.current = false
-  }, [token])
+  }, [token, verifyLogin])
 
   return(
     <div className={styles.root}>

--- a/src/pages/shoppingListPage/shoppingListPage.js
+++ b/src/pages/shoppingListPage/shoppingListPage.js
@@ -32,7 +32,7 @@ const ShoppingListPage = () => {
     if (e.key === 'Escape' || !formRefContains(e.target)) {
       setListItemEditFormVisible(false)
     }
-  }, [])
+  }, [setListItemEditFormVisible])
 
   useEffect(() => {
     window.addEventListener('keyup', hideForm)

--- a/src/pages/shoppingListPage/shoppingListPage.js
+++ b/src/pages/shoppingListPage/shoppingListPage.js
@@ -22,12 +22,6 @@ const ShoppingListPage = () => {
 
   const formRefContains = el => formRef.current && (formRef.current === el || formRef.current.contains(el))
 
-  // const hideForm = e => {
-  //   if (e.key === 'Escape' || !formRefContains(e.target)) {
-  //     setListItemEditFormVisible(false)
-  //   }
-  // }
-
   const hideForm = useCallback(e => {
     if (e.key === 'Escape' || !formRefContains(e.target)) {
       setListItemEditFormVisible(false)

--- a/src/pages/shoppingListPage/shoppingListPage.js
+++ b/src/pages/shoppingListPage/shoppingListPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useCallback } from 'react'
 import { useShoppingListContext } from '../../hooks/contexts'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
@@ -22,11 +22,17 @@ const ShoppingListPage = () => {
 
   const formRefContains = el => formRef.current && (formRef.current === el || formRef.current.contains(el))
 
-  const hideForm = e => {
+  // const hideForm = e => {
+  //   if (e.key === 'Escape' || !formRefContains(e.target)) {
+  //     setListItemEditFormVisible(false)
+  //   }
+  // }
+
+  const hideForm = useCallback(e => {
     if (e.key === 'Escape' || !formRefContains(e.target)) {
       setListItemEditFormVisible(false)
     }
-  }
+  }, [])
 
   useEffect(() => {
     window.addEventListener('keyup', hideForm)


### PR DESCRIPTION
## Context

[**Straighten out dependencies in useEffect hooks**](https://trello.com/c/ezdyV4qJ/68-straighten-out-dependencies-in-useeffect-hooks)

We were getting a lot of console warnings about `useEffect` hooks having missing dependencies. Since a lot of these dependencies are functions that change on every render, I was reluctant to add them, so I created a card for the issue so I could come back to it when I had time to dedicate to it and prioritise it. 

## Changes

* Wrap functional dependencies of `useEffect` hooks in `useCallback` hooks so they could be added to the dependency arrays
* Add the functional dependencies to the dependency arrays of `useEffect` hooks

## Considerations

I didn't initially know how to use a `useCallback` hook so I thought this would be a complicated task, but it turned out to be pretty straightforward. I thought about wrapping more functions in the `useCallback` hooks but didn't see the advantage to it. I decided to not memoise additional functions until/unless they end up as dependencies of `useEffect` hooks in the future.

## Manual Test Cases

Visit each page in the site and click around a bit in dev. See that there are no React warnings about missing or unneeded dependencies in dependency arrays.

## Screenshots and GIFs

The pristine beauty of the JavaScript console without any warnings about `useEffect` dependencies 😎:

<img width="1680" alt="Screen Shot 2021-07-13 at 1 45 41 pm" src="https://user-images.githubusercontent.com/5115928/125387087-b4c63480-e3e0-11eb-8b3a-3c3982b853f4.png">

