### PR TITLE
Scroll to top of page when flash message displayed

### DIFF
--- a/src/components/flashMessage/flashMessage.module.css
+++ b/src/components/flashMessage/flashMessage.module.css
@@ -1,6 +1,7 @@
 .root {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
   font-size: 1.1rem;
+  line-height: 1.25;
   background-color: var(--body-color);
   color: var(--text-color);
   border: 1px solid var(--border-color);
@@ -16,7 +17,6 @@
 
 .header {
   margin-top: 0;
-  margin-bottom: 8px;
 }
 
 .messageList {

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -6,7 +6,7 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import SlideToggle from 'react-slide-toggle'
 import useComponentVisible from '../../hooks/useComponentVisible'
 import useSize from '../../hooks/useSize'
-import { useColorScheme, useShoppingListContext } from '../../hooks/contexts'
+import { useAppContext, useColorScheme, useShoppingListContext } from '../../hooks/contexts'
 import ShoppingListEditForm from '../shoppingListEditForm/shoppingListEditForm'
 import ShoppingListItem from '../shoppingListItem/shoppingListItem'
 import styles from './shoppingList.module.css'
@@ -36,12 +36,12 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
 
   const { componentRef, triggerRef, isComponentVisible, setIsComponentVisible } = useComponentVisible()
 
+  const { displayFlash, hideFlash } = useAppContext()
+
   const {
     shoppingLists,
     performShoppingListUpdate,
     performShoppingListDestroy,
-    setFlashProps,
-    setFlashVisible
   } = useShoppingListContext()
 
   const originalTitle = title // to switch back in case of API error on update
@@ -82,7 +82,7 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
   const submitAndHideForm = e => {
     e.preventDefault()
 
-    setFlashVisible(false)
+    hideFlash()
 
     const newTitle = e.nativeEvent.target.children[0].defaultValue
 
@@ -97,16 +97,12 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
 
     const confirmed = window.confirm(`Are you sure you want to delete the list "${title}"? You will also lose any list items on the list. This action cannot be undone.`)
 
-    setFlashVisible(false)
+    hideFlash()
 
     if (confirmed) {
       performShoppingListDestroy(listId)
     } else {
-      setFlashProps({
-        type: 'info',
-        message: 'Your list was not deleted.'
-      })
-      setFlashVisible(true)
+      displayFlash('info', 'Your list was not deleted.')
     }
   }
 

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -1,14 +1,15 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { BLUE } from '../../utils/colorSchemes'
-import { useShoppingListContext } from '../../hooks/contexts'
+import { useAppContext, useShoppingListContext } from '../../hooks/contexts'
 import styles from './shoppingListCreateForm.module.css'
 import classNames from 'classnames'
 
 const ShoppingListCreateForm = ({ disabled }) => {
+  const { hideFlash } = useAppContext()
+
   const {
-    performShoppingListCreate,
-    setFlashVisible
+    performShoppingListCreate
   } = useShoppingListContext()
 
   const [inputValue, setInputValue] = useState('')
@@ -27,7 +28,7 @@ const ShoppingListCreateForm = ({ disabled }) => {
 
   const createShoppingList = e => {
     e.preventDefault()
-    setFlashVisible(false)
+    hideFlash()
     const title = e.target.elements.title.value
     performShoppingListCreate(title, () => setInputValue(''))
   }

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
 import { faAngleUp, faAngleDown, faTimes } from '@fortawesome/free-solid-svg-icons'
-import { useColorScheme, useShoppingListContext } from '../../hooks/contexts'
+import { useAppContext, useColorScheme, useShoppingListContext } from '../../hooks/contexts'
 import SlideToggle from 'react-slide-toggle'
 import styles from './shoppingListItem.module.css'
 
@@ -23,6 +23,11 @@ const ShoppingListItem = ({
   const [currentQuantity, setCurrentQuantity] = useState(quantity)
 
   const {
+    displayFlash,
+    hideFlash,
+  } = useAppContext()
+
+  const {
     schemeColorDarkest,
     textColorPrimary,
     hoverColorDark,
@@ -37,8 +42,6 @@ const ShoppingListItem = ({
   const {
     performShoppingListItemUpdate,
     performShoppingListItemDestroy,
-    setFlashProps,
-    setFlashVisible,
     setListItemEditFormProps,
     setListItemEditFormVisible
   } = useShoppingListContext()
@@ -93,10 +96,7 @@ const ShoppingListItem = ({
       if (confirmed) {
         performShoppingListItemDestroy(itemId, () => { mountedRef.current = false })
       } else {
-        setFlashProps({
-          type: 'info', message: 'Your item was not deleted.'
-        })
-        setFlashVisible(true)
+        displayFlash('info', 'Your item was not deleted.')
       }
     }
   }
@@ -107,15 +107,12 @@ const ShoppingListItem = ({
     if (confirmed) {
       performShoppingListItemDestroy(itemId, () => { mountedRef.current = false })
     } else {
-      setFlashProps({
-        type: 'info', message: 'Your item was not deleted'
-      })
-      setFlashVisible(true)
+      displayFlash('info', 'Your item was not deleted.')
     }
   }
 
   const showEditForm = () => {
-    setFlashVisible(false)
+    hideFlash()
     setListItemEditFormProps({
       listTitle: listTitle,
       buttonColor: {

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
@@ -6,7 +6,7 @@ import styles from './shoppingListItemCreateForm.module.css'
 
 const ShoppingListItemCreateForm = ({ listId }) => {
   const [toggleEvent, setToggleEvent] = useState(0)
-  const { performShoppingListItemCreate, setFlashVisible } = useShoppingListContext()
+  const { performShoppingListItemCreate, hideFlash } = useShoppingListContext()
   const {
     schemeColorDark,
     hoverColorLight,
@@ -34,7 +34,7 @@ const ShoppingListItemCreateForm = ({ listId }) => {
   const createShoppingListItem = e => {
     e.preventDefault()
 
-    setFlashVisible(false)
+    hideFlash()
 
     const description = e.target.elements.description.value
     const quantity = Number(e.target.elements.quantity.value)

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.stories.js
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.stories.js
@@ -14,7 +14,6 @@ const appProviderOverrideValues = {
   profileData
 }
 
-const noop = () => {}
 
 const containerStyle = {
   position: 'absolute',
@@ -29,7 +28,7 @@ export default { title: 'ShoppingListItemEditForm' }
 
 export const Default = () => (
   <AppProvider overrideValue={appProviderOverrideValues}>
-    <ShoppingListProvider overrideValue={{ shoppingLists, setFlashProps: noop, setFlashVisible: noop }}>
+    <ShoppingListProvider overrideValue={{ shoppingLists }}>
       <div style={containerStyle}>
         <ShoppingListItemEditForm listTitle={shoppingLists[1].title} buttonColor={GREEN} currentAttributes={listItemData} />
       </div>

--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -51,6 +51,7 @@ const AppProvider = ({ children, overrideValue = {} }) => {
   const displayFlash = useCallback((type, message, header = null) => {
     setFlashProps({ type, message, header })
     setFlashVisible(true)
+    window.scrollTo(0, 0)
   }, [setFlashProps, setFlashVisible])
 
   const hideFlash = useCallback(() => { setFlashVisible(false) }, [setFlashVisible])

--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -32,6 +32,8 @@ const AppContext = createContext()
 // set the value for the context in the story,
 const AppProvider = ({ children, overrideValue = {} }) => {
   const [cookies, setCookie, removeCookie] = useCookies([sessionCookieName])
+  const [flashProps, setFlashProps] = useState({})
+  const [flashVisible, setFlashVisible] = useState(false)
   const [profileData, setProfileData] = useState(overrideValue.profileData)
   const [redirectPath, setRedirectPath] = useState(overrideValue.shouldRedirectTo)
   const [profileLoadState, setProfileLoadState] = useState(overrideValue.profileLoadState || LOADING)
@@ -46,6 +48,13 @@ const AppProvider = ({ children, overrideValue = {} }) => {
     mountedRef.current = false
   }, [mountedRef])
 
+  const displayFlash = useCallback((type, message, header = null) => {
+    setFlashProps({ type, message, header })
+    setFlashVisible(true)
+  }, [setFlashProps, setFlashVisible])
+
+  const hideFlash = useCallback(() => { setFlashVisible(false) }, [setFlashVisible])
+
   const value = {
     token: cookies[sessionCookieName],
     profileData,
@@ -53,6 +62,10 @@ const AppProvider = ({ children, overrideValue = {} }) => {
     setSessionCookie,
     profileLoadState,
     setShouldRedirectTo,
+    flashVisible,
+    flashProps,
+    displayFlash,
+    hideFlash,
     ...overrideValue // enables you to only change certain values
   }
 
@@ -121,13 +134,21 @@ AppProvider.propTypes = {
     profileData: PropTypes.shape({
       id: PropTypes.number,
       uid: PropTypes.string,
-      email: PropTypes.string,
-      name: PropTypes.string,
+      email: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
       image_url: PropTypes.string
     }),
     setSessionCookie: PropTypes.func,
     removeSessionCookie: PropTypes.func,
-    setProfileData: PropTypes.func
+    setProfileData: PropTypes.func,
+    flashVisible: PropTypes.bool,
+    flashProps: PropTypes.shape({
+      type: PropTypes.oneOf(['error', 'info', 'success']).isRequired,
+      message: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]).isRequired,
+      header: PropTypes.string
+    }),
+    displayFlash: PropTypes.func,
+    hideFlash: PropTypes.func
   })
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
@@ -13,4 +17,10 @@ body.modal-open {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+@media (prefers-reduced-motion) {
+  html {
+    scroll-behavior: auto;
+  }
 }

--- a/src/pages/shoppingListPage/shoppingListPage.js
+++ b/src/pages/shoppingListPage/shoppingListPage.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useCallback } from 'react'
-import { useShoppingListContext } from '../../hooks/contexts'
+import { useAppContext, useShoppingListContext } from '../../hooks/contexts'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
 import ShoppingListCreateForm from '../../components/shoppingListCreateForm/shoppingListCreateForm'
@@ -8,9 +8,9 @@ import styles from './shoppingListPage.module.css'
 import ShoppingListItemEditForm from '../../components/shoppingListItemEditForm/shoppingListItemEditForm'
 
 const ShoppingListPage = () => {
+  const { flashProps, flashVisible } = useAppContext()
+
   const {
-    flashProps,
-    flashVisible,
     listItemEditFormVisible,
     setListItemEditFormVisible,
     listItemEditFormProps,


### PR DESCRIPTION
## Context

[**Scroll to top of page when flash message displayed**](https://trello.com/c/D0zoz4LT/74-scroll-to-top-of-page-when-flash-message-displayed)

Currently, when the flash message appears above the shopping lists, it's possible the user will see no change on their page at all and therefore not see the message or even know it's there. If the message is so important to users, we should make sure they see it.

Although this card is just to make SIM scroll to the top of the page when the flash is made visible, I'm including more work as part of this PR. The flash component logic lived in the `ShoppingListProvider`, but it made more sense for it to be in the `AppProvider` given that it will be used on other pages as well.

Unfortunately, smooth scrolling is not supported (of course) in Safari, which is the shittiest browser and makes me not want to buy iOS devices anymore. I decided not to implement more complicated JS to make the smooth scrolling work there, especially given some users will opt out anyway.

## Changes

* Move flash control functions and state to the `AppProvider` from the `ShoppingListProvider`
* Expose memoised `displayFlash` and `hideFlash` functions in the provider's `value`
* Scroll to the top smoothly* when the flash message is displayed

## Considerations

I realised that the `setFlashProps` and `setFlashVisible(true)` functions were being called a lot at the same time, and it was easier to extract these functions into a `displayFlash` function that takes the message, type, and header as arguments and both sets the props and the display state of the component. That also made a convenient place for the scrolling to happen. In order to be symmetrical about it, I also included a `hideFlash()` function that hides the `FlashMessage` component.

Although I and many users strongly prefer smooth scrolling on web sites, not all users do. Some set their browsers to avoid unnecessary movement on the pages they visit. So when I set the CSS for smooth scrolling, I also created a `prefers-reduced-motion` media query setting the scrolling to 'auto' so those users' preferences are respected.

I'm not sure if this scrolling feature will end up being good or bad for users. I'm going to use it this way for a while and see if it is helpful or starts to annoy me.

## Manual Test Cases

1. Create enough shopping lists that you can scroll down until the flash component is out of view.
2. Scroll to the bottom list and click its delete icon
3. Click cancel when prompted
4. See that you are scrolled to the top to see the message

## Screenshots and GIFs

![issue-74](https://user-images.githubusercontent.com/5115928/125416759-417b171a-1ad0-408b-aa2f-fb9d06625312.gif)

