### PR TITLE
Introduce Jest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: Skyrim Inventory Management Frontend CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Node Modules
+      run: yarn
+    - name: Run tests
+      run: yarn test

--- a/README.md
+++ b/README.md
@@ -71,6 +71,35 @@ export const Default = () => <DashboardProvider overrideValue={overrideValue}><D
 ```
 For other cases where you absolutely must change app behaviour for Storybook, you can use the [`isStorybook`](/src/utils/isStorybook.js) function. Use of this function should be considered a code smell and avoided when possible.
 
+### Testing with Jest
+
+[Jest](https://jestjs.io/) has been set up with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro) to handle testing of components. We are in the process of [retrofitting tests](https://trello.com/c/ulddni7U/78-testing-with-jest) to the application, so tests will be added to components that don't currently have them.
+
+It is recommended, per the docs, to take a behaviour-based approach to testing with Jest, using the React Testing Library tooling to interact with elements like a user would. It's important that we write these tests with an eye to ensuring complete coverage of underlying logic, however. Most of the logic in the SIM front-end is in contexts and hooks, not in the components themselves, and we should make sure the tests simulate situations that will trigger this logic to run and test the outcome.
+
+To run the Jest tests, you'll need to first run `yarn install` to make sure your dependencies are installed and up-to-date. To run the tests, run:
+```
+yarn test
+```
+This will run the tests in watch mode, running tests every time you save a file. Not all tests will run on every save - by default, Jest only reruns tests touching files that have changed since the last commit. You can press `q` to exit watch mode and go back to your terminal.
+
+#### API Mocking
+
+We use [MSW](https://mswjs.io/docs/getting-started) for mocking API calls in Jest (as well as Storybook). While MSW recommends mocking all API calls centrally, we have opted not to do that. The reason for this is that the outcome of our API calls cannot be determined solely by the request, but also by the state of records in the database and token validation. It's too hard to make centralised handlers that cover all the needed cases, so it's better to just set up a mock server in each of the tests where one is required and define the handlers there. For an example of this, see the [homepage test file](/src/pages/homePage/homePage.test.js).
+
+### GitHub Actions
+
+Jest has been configured to run in CI with GitHub actions. It runs against all pull requests against `main`, as well as when `main` is merged. After merging new code, make sure the build has passed before deploying to Heroku.
+
+When working on an epic on a feature branch, you may want to configure GitHub Actions to run against PRs against the feature branch (or merges to that branch) and not just `main`. This can be done in the [pipeline definition file](/.github/workflows/ci.yml) by changing the following block:
+```yml
+on:
+  push:
+    branches: [main, your-feature-branch]
+  pull_request:
+    branches: [main, your-feature-branch]
+```
+
 ### Deployment
 
 The SIM front end is deployed to [Heroku](https://heroku.com) under the app name `obscure-reaches-80056`. Deployment is done manually via the command line and Git. It is recommended to install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) to work with Heroku.

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/pages/homePage/homePage.test.js
+++ b/src/pages/homePage/homePage.test.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { cleanup, waitFor } from '@testing-library/react'
+import { renderWithRouter } from '../../setupTests'
+import { AppProvider } from '../../contexts/appContext'
+import HomePage from './homePage'
+
+describe('HomePage', () => {
+  describe('when the user is signed in', () => {
+    const server = setupServer(
+      rest.get('http://localhost:3000/auth/verify_token', (req, res, ctx) => {
+        return res(ctx.status(204))
+      })
+    )
+
+    beforeAll(() => server.listen())
+    beforeEach(() => server.resetHandlers())
+    afterAll(() => server.close())
+
+    it('redirects to the login page', async () => {
+      const { history } = renderWithRouter(<AppProvider overrideValue={{ token: 'xxxxxx' }}><HomePage /></AppProvider>)
+
+      await waitFor(() => expect(history.location.pathname).toEqual('/dashboard'))
+    })
+  })
+
+  describe('when the user is not signed in', () => {
+    const server = setupServer(
+      rest.get('http://localhost:3000/auth/verify_token', (req, res, ctx) => {
+        return res(
+          ctx.status(401),
+          ctx.json({ errors: ['Google OAuth token validation error'] })
+        )
+      })
+    )
+
+    beforeAll(() => server.listen())
+    beforeEach(() => server.resetHandlers())
+    afterAll(() => server.close())
+
+    it('stays on the homepage', async () => {
+      const { history } = renderWithRouter(<AppProvider overrideValue={{ token: 'xxxxxx' }}><HomePage /></AppProvider>)
+
+      await waitFor(() => { expect(history.location.pathname).toEqual('/') })
+    })
+  })
+})

--- a/src/pages/homePage/homePage.test.js
+++ b/src/pages/homePage/homePage.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
-import { cleanup, waitFor } from '@testing-library/react'
+import {  waitFor, screen, fireEvent } from '@testing-library/react'
 import { renderWithRouter } from '../../setupTests'
 import { AppProvider } from '../../contexts/appContext'
 import HomePage from './homePage'
@@ -42,7 +42,29 @@ describe('HomePage', () => {
     it('stays on the homepage', async () => {
       const { history } = renderWithRouter(<AppProvider overrideValue={{ token: 'xxxxxx' }}><HomePage /></AppProvider>)
 
-      await waitFor(() => { expect(history.location.pathname).toEqual('/') })
+      await waitFor(() => expect(history.location.pathname).toEqual('/'))
+    })
+
+    it('displays the homepage title', async () => {
+      renderWithRouter(<AppProvider overrideValue={{ token: 'xxxxxx' }}><HomePage /></AppProvider>)
+      
+      expect(screen.getByText(/skyrim inventory management/i)).toBeInTheDocument()
+    })
+
+    it('links to the login page', async () => {
+      renderWithRouter(<AppProvider overrideValue={{ token: 'xxxxxx' }}><HomePage /></AppProvider>)
+
+      expect(screen.getByText(/log in with google/i)).toBeInTheDocument()
+    })
+
+    describe('clicking the login link', () => {
+      it('goes to the login page', async () => {
+        const { history } = renderWithRouter(<AppProvider overrideValue={{ token: 'xxxxxx' }}><HomePage /></AppProvider>)
+
+        const link = await screen.getByText(/log in with google/i)
+        fireEvent.click(link)
+        await waitFor(() => expect(history.location.pathname).toEqual('/login'))
+      })
     })
   })
 })

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,4 +2,15 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import React from 'react'
+import { Router } from 'react-router-dom'
+import { render } from '@testing-library/react'
+import { createMemoryHistory } from 'history'
+import '@testing-library/jest-dom'
+
+export const renderWithRouter = (ui, { route = '/', history = createMemoryHistory({ initialEntries: [route] }) } = {}) => {
+  return {
+    ...render(<Router history={history}>{ui}</Router>),
+    history
+  }
+}


### PR DESCRIPTION
## Context

[**Introduce Jest**](https://trello.com/c/2ux0MwqZ/69-introduce-jest)

After shipping an entire feature and a bunch of glue work, it is well past time to add some tests to the front-end. React ships with Jest and I've had good experiences with Jest in the past (although I haven't used it much), so it seemed like a good choice.

## Changes

* Add Jest setup and config to `setupTests.js`
* Add tests for the `HomePage` component
* Set up GitHub Actions for CI

## Considerations

### MSW for API Mocking

I decided to use MSW for mock API calls. [They suggest(https://mswjs.io/docs/getting-started/integrate/node) setting up all your handlers in a single file and importing them to the single `setupTests.js` file where you set up your server, but I didn't see a good way to do that without implementing the whole API in JavaScript to capture the full range of possible responses. Not to mention, I need to be able to choose different responses for different endpoints, depending not on the request but other factors (such as the presence of a valid token, which just has to be mocked.)

There were other options for API calls, such as Jest mocks, but it made sense to use MSW since I was already using it for Storybook, even though it did require just as much setup to use as it does there.

### Testing Approach and Coverage

The React Testing Library docs suggest testing components rather than internal logic. I'd like to have some unit testing capabilities for the logic-heavy contexts and hooks, but it seems it isn't recommended to use this tool for testing "internals". I would like to have tests to tell me how often things are rendering, etc., because I feel like there may be some inefficiencies in that area that we won't catch just by checking that the right thing is rendering and it's redirecting to the right places. I'll look into other tools or approaches for doing that because I feel testing both behaviour and implementation is important.

### Directory Structure

Per the docs, there are a few ways to set up tests. Tests must live in the `src` directory but there are various options for how to structure them. Any `.js` file in a `/src/**/__tests__` directory will be run when tests run. Likewise, any file in the `/src` directory that ends in `.spec.js` or `.test.js` will be run as a test file.

I decided to use `.test.js` files, included in the directories with the components they test alongside the components themselves, the CSS modules, and the Storybook stories for those components. If there end up being multiple test files for some components, or auxiliary files such as those including test data, we may move some or all of these files into `__test__` directories in the future. 