### PR TITLE
Create GamesContext to manage user games

### DIFF
--- a/src/components/shoppingListPageContent/shoppingListPageContent.js
+++ b/src/components/shoppingListPageContent/shoppingListPageContent.js
@@ -2,9 +2,12 @@ import React from 'react'
 import colorSchemes, { YELLOW } from '../../utils/colorSchemes'
 import { useShoppingListContext } from '../../hooks/contexts'
 import { ColorProvider } from '../../contexts/colorContext'
+import { shoppingListLoadingStates } from '../../contexts/shoppingListContext'
 import Loading from '../loading/loading'
 import ShoppingList from '../shoppingList/shoppingList'
 import styles from './shoppingListPageContent.module.css'
+
+const { LOADING, DONE } = shoppingListLoadingStates
 
 const ShoppingListPageContent = () => {
   const { shoppingLists, shoppingListLoadingState } = useShoppingListContext()
@@ -16,7 +19,7 @@ const ShoppingListPageContent = () => {
    */
 
   // Expected states
-  const listsLoadedAndNotEmpty = shoppingLists && shoppingListLoadingState === 'done' && shoppingLists.length > 0
+  const listsLoadedAndNotEmpty = shoppingLists && shoppingListLoadingState === DONE && shoppingLists.length > 0
 
   /*
    *
@@ -47,7 +50,7 @@ const ShoppingListPageContent = () => {
         })}
       </>
     )
-  } else if (shoppingListLoadingState === 'loading') {
+  } else if (shoppingListLoadingState === LOADING) {
     return <Loading className={styles.loading} color={YELLOW.schemeColorDarkest} height='15%' width='15%' />
   } else {
     return null

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -98,7 +98,7 @@ GamesProvider.propTypes = {
       name: PropTypes.string.isRequired,
       description: PropTypes.string
     })),
-    gameLoadingState: PropTypes.oneOf(['loading', 'done', 'error'])
+    gameLoadingState: PropTypes.oneOf([LOADING, DONE, ERROR])
   })
 }
 

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -20,6 +20,8 @@ const LOADING = 'loading'
 const DONE = 'done'
 const ERROR = 'error'
 
+const gameLoadingStates = { LOADING, DONE, ERROR }
+
 const GamesContext = createContext()
 
 const GamesProvider = ({ children, overrideValue = {} }) => {
@@ -100,4 +102,4 @@ GamesProvider.propTypes = {
   })
 }
 
-export { GamesContext, GamesProvider }
+export { GamesContext, GamesProvider, gameLoadingStates }

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -1,0 +1,103 @@
+/*
+ *
+ * For more information about contexts and how they are used in SIM,
+ * visit the docs on SIM contexts (/docs/contexts.md)
+ * 
+ * This context makes heavy use of the SIM API. The requests it makes are
+ * mediated through the simApi module (/src/utils/simApi.js). To get information
+ * about the API, its requirements, and its responses, visit the docs:
+ * https://github.com/danascheider/skyrim_inventory_management/tree/main/docs/api
+ *
+ */
+
+import { createContext, useState, useEffect, useRef, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import { fetchGames } from '../utils/simApi'
+import { useAppContext } from '../hooks/contexts'
+import paths from '../routing/paths'
+
+const LOADING = 'loading'
+const DONE = 'done'
+const ERROR = 'error'
+
+const GamesContext = createContext()
+
+const GamesProvider = ({ children, overrideValue = {} }) => {
+  const { token, logOutAndRedirect, displayFlash } = useAppContext()
+
+  const [games, setGames] = useState(overrideValue.games || [])
+  const [gameLoadingState, setGameLoadingState] = useState(overrideValue.gameLoadingState || LOADING)
+
+  const mountedRef = useRef(true)
+  const gamesOverridden = useRef(false)
+
+  if (overrideValue.games) {
+    // Use this as the initial value only so that the games can be
+    // updated when we interact in Storybook or other tests
+    delete overrideValue.games
+    gamesOverridden.current = true
+  }
+
+  const fetchUserGames = useCallback(() => {
+    if (token && !gamesOverridden.current) {
+      fetchGames(token)
+        .then(resp => resp.json())
+        .then(data => {
+          if (data && !data.errors) {
+            if (mountedRef.current) {
+              setGames(data)
+              !overrideValue.gameLoadingState && setGameLoadingState(DONE)
+            }
+          } else {
+            const message = data && data.errors ? `Internal Server Error: ${data.errors[0]}` : 'No game data returned from SIM'
+            throw new Error(message)
+          }
+        })
+        .catch(err => {
+          if (err.code === 401) {
+            logOutAndRedirect(paths.login, () => mountedRef.current = false)
+            // Don't set the loading state because it's redirecting anyway
+          } else {
+            if (process.env.NODE_ENV === 'development') console.error('Unexpected error fetching games: ', err)
+
+            if (mountedRef.current) {
+              setGameLoadingState(ERROR)
+              displayFlash('error', "There was an error loading your games. It may have been on our end. We're sorry!")
+            }
+          }
+        })
+    }
+  }, [token, overrideValue.gameLoadingState, displayFlash, logOutAndRedirect])
+
+  const value = {
+    games,
+    gameLoadingState,
+    ...overrideValue
+  }
+
+  useEffect(() => {
+    fetchUserGames()
+    return () => mountedRef.current = false
+  }, [fetchUserGames])
+
+  return(
+    <GamesContext.Provider value={value}>
+      {children}
+    </GamesContext.Provider>
+  )
+}
+
+GamesProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  overrideValue: PropTypes.shape({
+    games: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number,
+      user_id: PropTypes.number,
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string
+    })),
+    gameLoadingState: PropTypes.oneOf(['loading', 'done', 'error'])
+  })
+}
+
+export { GamesContext, GamesProvider }

--- a/src/contexts/shoppingListContext.js
+++ b/src/contexts/shoppingListContext.js
@@ -45,7 +45,8 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
   
   if (overrideValue.shoppingLists) {
     // Use this as the initial value only so that the shopping
-    // lists can be updated when we interact in Storybook
+    // lists can be updated when we interact in Storybook or other
+    // tests
     delete overrideValue.shoppingLists
     shoppingListsOverridden.current = true
   }
@@ -92,7 +93,7 @@ const ShoppingListProvider = ({ children, overrideValue = {} }) => {
             setShoppingLists(data)
             overrideValue.shoppingListLoadingState === undefined && setShoppingListLoadingState(DONE)
           } else {
-            const message = data && data.errors ? 'Internal ServerError: ' + data.errors[0] : 'No shopping list data returned from the SIM API'
+            const message = data && data.errors ? `Internal ServerError: ${data.errors[0]}` : 'No shopping list data returned from the SIM API'
             throw new Error(message)
           }
         })
@@ -488,7 +489,7 @@ ShoppingListProvider.propTypes = {
         notes: PropTypes.string
       })).isRequired
     })),
-    shoppingListLoadingState: PropTypes.string,
+    shoppingListLoadingState: PropTypes.oneOf(['loading', 'done', 'error']),
     performShoppingListUpdate: PropTypes.func,
     performShoppingListCreate: PropTypes.func,
     performShoppingListDestroy: PropTypes.func,
@@ -498,4 +499,4 @@ ShoppingListProvider.propTypes = {
   })
 }
 
-export { ShoppingListContext, ShoppingListProvider}
+export { ShoppingListContext, ShoppingListProvider }

--- a/src/contexts/shoppingListContext.js
+++ b/src/contexts/shoppingListContext.js
@@ -28,6 +28,8 @@ const LOADING = 'loading'
 const DONE = 'done'
 const ERROR = 'error'
 
+const shoppingListLoadingStates = { LOADING, DONE, ERROR }
+
 const ShoppingListContext = createContext()
 
 const ShoppingListProvider = ({ children, overrideValue = {} }) => {
@@ -499,4 +501,4 @@ ShoppingListProvider.propTypes = {
   })
 }
 
-export { ShoppingListContext, ShoppingListProvider }
+export { ShoppingListContext, ShoppingListProvider, shoppingListLoadingStates }

--- a/src/contexts/shoppingListContext.js
+++ b/src/contexts/shoppingListContext.js
@@ -491,7 +491,7 @@ ShoppingListProvider.propTypes = {
         notes: PropTypes.string
       })).isRequired
     })),
-    shoppingListLoadingState: PropTypes.oneOf(['loading', 'done', 'error']),
+    shoppingListLoadingState: PropTypes.oneOf([LOADING, DONE, ERROR]),
     performShoppingListUpdate: PropTypes.func,
     performShoppingListCreate: PropTypes.func,
     performShoppingListDestroy: PropTypes.func,

--- a/src/hooks/contexts.js
+++ b/src/hooks/contexts.js
@@ -8,6 +8,7 @@
 import { useContext } from 'react'
 import { ColorContext } from '../contexts/colorContext'
 import { AppContext } from '../contexts/appContext'
+import { GamesContext } from '../contexts/gamesContext'
 import { ShoppingListContext } from '../contexts/shoppingListContext'
 
 const useCustomContext = (cxt, msg) => {
@@ -30,4 +31,8 @@ export const useAppContext = () => (
 
 export const useShoppingListContext = () => (
   useCustomContext(ShoppingListContext, 'useShoppingListContext must be used within a ShoppingListProvider')
+)
+
+export const useGamesContext = () => (
+  useCustomContext(GamesContext, 'useGamesContext must be used within a GamesProvider')
 )

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import { YELLOW } from '../../utils/colorSchemes'
 import { useAppContext, useGamesContext } from '../../hooks/contexts'
+import { gameLoadingStates } from '../../contexts/gamesContext'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
 import Game from '../../components/game/game'
 import Loading from '../../components/loading/loading'
 import styles from './gamesPage.module.css'
+
+const { LOADING, DONE } = gameLoadingStates
 
 const GamesPage = () => {
   const {
@@ -19,11 +22,11 @@ const GamesPage = () => {
     <DashboardLayout title='Your Games'>
       <div className={styles.root}>
         {flashVisible && <FlashMessage {...flashProps} />}
-        {games && games.length === 0 && gameLoadingState === 'done' && <p className={styles.noGames}>You have no games.</p>}
-        {games && games.length > 0 && gameLoadingState === 'done' && <div className={styles.games}>
+        {games && games.length === 0 && gameLoadingState === DONE && <p className={styles.noGames}>You have no games.</p>}
+        {games && games.length > 0 && gameLoadingState === DONE && <div className={styles.games}>
           {games.map(({ name, description }) => <Game key={name} name={name} description={description} />)}
         </div>}
-        {gameLoadingState === 'loading' && <Loading type='bubbles' className={styles.loading} color={YELLOW.schemeColorDarkest} height='15%' width='15%' />}
+        {gameLoadingState === LOADING && <Loading type='bubbles' className={styles.loading} color={YELLOW.schemeColorDarkest} height='15%' width='15%' />}
       </div>
     </DashboardLayout>
   )

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -1,79 +1,29 @@
-import React, { useState, useEffect, useRef } from 'react'
-import { isStorybook } from '../../utils/isTestEnv'
-import { fetchGames } from '../../utils/simApi'
+import React from 'react'
 import { YELLOW } from '../../utils/colorSchemes'
-import { useAppContext } from '../../hooks/contexts'
+import { useAppContext, useGamesContext } from '../../hooks/contexts'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
 import Game from '../../components/game/game'
 import Loading from '../../components/loading/loading'
 import styles from './gamesPage.module.css'
-import paths from '../../routing/paths'
-
-const LOADING = 'loading'
-const DONE = 'done'
-const ERROR = 'error'
 
 const GamesPage = () => {
   const {
-    token,
-    logOutAndRedirect,
-    setShouldRedirectTo,
-    displayFlash,
     flashProps,
     flashVisible
   } = useAppContext()
 
-  const [games, setGames] = useState(null)
-  const [gameLoadingState, setGameLoadingState] = useState(LOADING)
-
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    if (!token && !isStorybook) {
-      setShouldRedirectTo(paths.login)
-      mountedRef.current = false
-    } else if (token) {
-      fetchGames(token)
-        .then(resp => resp.json())
-        .then(data => {
-          if (data && !data.errors) {
-            if (mountedRef.current) {
-              setGames(data)
-              setGameLoadingState(DONE)
-            }
-          } else {
-            const message = data && data.errors ? 'Internal ServerError: ' + data.errors[0] : 'No game data returned from SIM'
-            throw new Error(message)
-          }
-        })
-        .catch(err => {
-          if (err.code === 401) {
-            logOutAndRedirect(paths.login, () => mountedRef.current = false)
-            // Don't set the loading state because it's redirecting anyway
-          } else {
-            if (process.env.NODE_ENV === 'development') console.error('Unexpected error fetching games: ', err.message)
-
-            if (mountedRef.current) {
-              setGameLoadingState(ERROR)
-              displayFlash('error', "There was an error loading your games. It may have been on our end. We're sorry!")
-            }
-          }
-        })
-    }
-    
-    return () => mountedRef.current = false
-  }, [token, logOutAndRedirect, setShouldRedirectTo, displayFlash])
+  const { games, gameLoadingState } = useGamesContext()
 
   return(
     <DashboardLayout title='Your Games'>
       <div className={styles.root}>
         {flashVisible && <FlashMessage {...flashProps} />}
-        {games && games.length === 0 && gameLoadingState === DONE && <p className={styles.noGames}>You have no games.</p>}
-        {games && games.length > 0 && gameLoadingState === DONE && <div className={styles.games}>
+        {games && games.length === 0 && gameLoadingState === 'done' && <p className={styles.noGames}>You have no games.</p>}
+        {games && games.length > 0 && gameLoadingState === 'done' && <div className={styles.games}>
           {games.map(({ name, description }) => <Game key={name} name={name} description={description} />)}
         </div>}
-        {gameLoadingState === LOADING && <Loading type='bubbles' className={styles.loading} color={YELLOW.schemeColorDarkest} height='15%' width='15%' />}
+        {gameLoadingState === 'loading' && <Loading type='bubbles' className={styles.loading} color={YELLOW.schemeColorDarkest} height='15%' width='15%' />}
       </div>
     </DashboardLayout>
   )

--- a/src/pages/gamesPage/gamesPage.stories.js
+++ b/src/pages/gamesPage/gamesPage.stories.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { rest } from 'msw'
 import { backendBaseUri } from '../../utils/config'
 import { AppProvider } from '../../contexts/appContext'
+import { GamesProvider } from '../../contexts/gamesContext'
 import { profileData, emptyGames, games } from './testData'
 import GamesPage from './gamesPage'
 
@@ -22,7 +23,9 @@ export default { title: 'GamesPage' }
 
 export const HappyPath = () => (
   <AppProvider overrideValue={appContextOverrideValue}>
-    <GamesPage />
+    <GamesProvider overrideValue={{ gameLoadingState: 'done', games }}>
+      <GamesPage />
+    </GamesProvider>
   </AppProvider>
 )
 
@@ -45,7 +48,9 @@ HappyPath.parameters = {
 
 export const Empty = () => (
   <AppProvider overrideValue={appContextOverrideValue}>
-    <GamesPage />
+    <GamesProvider overrideValue={{ gameLoadingState: 'done', games: emptyGames }}>
+      <GamesPage />
+    </GamesProvider>
   </AppProvider>
 )
 
@@ -62,6 +67,20 @@ Empty.parameters = {
 
 /*
  *
+ * When the games are loading
+ *
+ */
+
+export const Loading = () => (
+  <AppProvider overrideValue={appContextOverrideValue}>
+    <GamesProvider overrideValue={{ gameLoadingState: 'loading', games: emptyGames }}>
+      <GamesPage />
+    </GamesProvider>
+  </AppProvider>
+)
+
+/*
+ *
  * When the server returns a 500 error or another unexpected
  * error is raised
  *
@@ -69,7 +88,9 @@ Empty.parameters = {
 
 export const Error = () => (
   <AppProvider overrideValue={appContextOverrideValue}>
-    <GamesPage />
+    <GamesProvider>
+      <GamesPage />
+    </GamesProvider>
   </AppProvider>
 )
 

--- a/src/pages/gamesPage/gamesPage.test.js
+++ b/src/pages/gamesPage/gamesPage.test.js
@@ -13,6 +13,7 @@ import { Cookies, CookiesProvider } from 'react-cookie'
 import { renderWithRouter } from '../../setupTests'
 import { backendBaseUri } from '../../utils/config'
 import { AppProvider } from '../../contexts/appContext'
+import { GamesProvider } from '../../contexts/gamesContext'
 import { profileData, games, emptyGames } from './testData'
 import GamesPage from './gamesPage'
 
@@ -28,7 +29,7 @@ describe('GamesPage', () => {
 
     it('redirects to the login page', async () => {
       act(() => {
-        component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+        component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
         return undefined
       })
       const { history } = component
@@ -62,7 +63,7 @@ describe('GamesPage', () => {
 
     it('redirects to the login page', async () => {
       act(() => {
-        component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+        component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
         return undefined
       })
       const { history } = component
@@ -98,7 +99,7 @@ describe('GamesPage', () => {
 
         it('stays on the games page', async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
           const { history } = component
@@ -108,7 +109,7 @@ describe('GamesPage', () => {
 
         it('displays the games page', async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -119,7 +120,7 @@ describe('GamesPage', () => {
 
         it('displays a message that there are no games', async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -130,7 +131,7 @@ describe('GamesPage', () => {
 
         it("doesn't display an error message", async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -160,7 +161,7 @@ describe('GamesPage', () => {
 
         it('stays on the games page', async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
           const { history } = component
@@ -170,7 +171,7 @@ describe('GamesPage', () => {
 
         it('displays the games page', async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -181,7 +182,7 @@ describe('GamesPage', () => {
 
         it('displays the list of games', async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -194,7 +195,7 @@ describe('GamesPage', () => {
 
         it("doesn't display the 'You have no games' message", async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -203,7 +204,7 @@ describe('GamesPage', () => {
 
         it("doesn't display an error message", async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -212,7 +213,7 @@ describe('GamesPage', () => {
 
         it("doesn't display the descriptions to start with", async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -222,7 +223,7 @@ describe('GamesPage', () => {
 
         it('expands one description at a time', async () => {
           act(() => {
-            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+            component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
             return undefined
           })
 
@@ -270,7 +271,7 @@ describe('GamesPage', () => {
 
       it('stays on the games page', async () => {
         act(() => {
-          component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+          component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
           return undefined
         })
         const { history } = component
@@ -280,7 +281,7 @@ describe('GamesPage', () => {
 
       it("doesn't display the 'You have no games' message", async () => {
         act(() => {
-          component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+          component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
           return undefined
         })
 
@@ -289,7 +290,7 @@ describe('GamesPage', () => {
 
       it('displays an error message', async () => {
         act(() => {
-          component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesPage /></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
+          component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><GamesProvider><GamesPage /></GamesProvider></AppProvider></CookiesProvider>, { route: '/dashboard/games' })
           return undefined
         })
 

--- a/src/pages/shoppingListPage/shoppingListPage.js
+++ b/src/pages/shoppingListPage/shoppingListPage.js
@@ -1,11 +1,14 @@
 import React, { useEffect, useRef, useCallback } from 'react'
 import { useAppContext, useShoppingListContext } from '../../hooks/contexts'
+import { shoppingListLoadingStates } from '../../contexts/shoppingListContext'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
 import ShoppingListCreateForm from '../../components/shoppingListCreateForm/shoppingListCreateForm'
 import ShoppingListPageContent from '../../components/shoppingListPageContent/shoppingListPageContent'
 import styles from './shoppingListPage.module.css'
 import ShoppingListItemEditForm from '../../components/shoppingListItemEditForm/shoppingListItemEditForm'
+
+const { LOADING, ERROR }
 
 const ShoppingListPage = () => {
   const { flashProps, flashVisible } = useAppContext()
@@ -17,7 +20,7 @@ const ShoppingListPage = () => {
     shoppingListLoadingState
   } = useShoppingListContext()
 
-  const shouldDisableForm = shoppingListLoadingState === 'loading' || shoppingListLoadingState === 'error'
+  const shouldDisableForm = shoppingListLoadingState === LOADING || shoppingListLoadingState === ERROR
   const formRef = useRef(null)
 
   const formRefContains = el => formRef.current && (formRef.current === el || formRef.current.contains(el))

--- a/src/routing/pageRoutes.js
+++ b/src/routing/pageRoutes.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Switch, Route } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import { AppProvider } from '../contexts/appContext'
+import { GamesProvider } from '../contexts/gamesContext'
 // import { ShoppingListProvider } from '../contexts/shoppingListContext'
 import HomePage from '../pages/homePage/homePage'
 import LoginPage from '../pages/loginPage/loginPage'
@@ -39,7 +40,7 @@ const pages = [
     pageId: 'games',
     title: `${siteTitle} Your Games`,
     description: 'Manage Skyrim Games',
-    jsx: <GamesPage />,
+    jsx: <GamesProvider><GamesPage /></GamesProvider>,
     path: paths.dashboard.games
   },
   // {


### PR DESCRIPTION
## Context

[**Create GameContext**](https://trello.com/c/XVkZ30Jw/104-create-gamecontext)

We've created a Games page on the user's dashboard, but currently, the page component fetches games in its own `useEffect` hook. Since we know games will be needed elsewhere, it's better to create a `GamesContext` that will fetch the games and make them available to all its consumers.

## Changes

* Create `GamesContext` and `GamesProvider` that fetches games and sets their loading state
* Create `useGamesContext` hook for context consumers
* Update Jest and Storybook to use the required provider
* Update docs

## Manual Test Cases

This PR shouldn't change any functionality or visuals, so we should just make sure it hasn't broken anything.