### PR TITLE
Enable users to destroy games from the front end

### DIFF
--- a/docs/contexts/games-context.md
+++ b/docs/contexts/games-context.md
@@ -46,7 +46,7 @@ Function to update a game. Takes three possible arguments:
   * `onUnauthorized`: Runs when the server returns a 401 response
   * `onNotFound`: Runs when the server returns a 404 response
   * `onUnprocessableEntity`: Runs when the server returns a 422 response
-  * `onInternalServerError`: Runs when the server returns a 500 response or an error is thrown while handling the response from the server
+  * `onInternalServerError`: Runs when the server returns a 500-range response or an error is thrown while handling the response from the server
 
 The callback functions passed in are run after the context provider's own handlers complete. These handlers perform logic as follows:
 
@@ -56,7 +56,22 @@ The callback functions passed in are run after the context provider's own handle
 * **On a 422 response**, hides the form and displays a flash message with the validation errors (if consumers render one)
 * **On a 500-range response**, hides the form and displays a flash error message (if consumers render one)
 
-Note that no callbacks are run if the server returns a 401 error.
+### `performGameDestroy`
+
+Function to destroy/delete a game. Takes two possible arguments:
+
+* `gameId` (required): The ID of the game to be deleted
+* `callbacks`: Up to three optional callbacks to handle any success or error state, typically used to unmount a componeent or do other cleanup work. The possible functions are:
+  * `onSuccess`: Runs when the server reeturns a 200-range response _or_ a 404 response
+  * `onUnauthorized`: Runs when the server returns a 401 response
+  * `onInternalServerError`: Runs when tthe server returns a 500-range response or an ereror is thrown while handling the response from the server.
+
+Thee callback functions passed in are run after the context provider's own handlers complete. These handlers perform logic as follows:
+
+* **On a 200-range response**, removes the deleted game from the UI
+* **On a 401 response**, logs the user out and redirects them to the login page, unmounting the context provider
+* **On a 404 response**, behaves as a successful deletion (since the game is already gone and that's what the user wanted)
+* **On a 500-range response**, doesn't remove the game from the UI and displays a flash error message
 
 ### `gameEditFormVisible`
 

--- a/docs/contexts/games-context.md
+++ b/docs/contexts/games-context.md
@@ -64,7 +64,7 @@ Function to destroy/delete a game. Takes two possible arguments:
 * `callbacks`: Up to three optional callbacks to handle any success or error state, typically used to unmount a componeent or do other cleanup work. The possible functions are:
   * `onSuccess`: Runs when the server reeturns a 200-range response _or_ a 404 response
   * `onUnauthorized`: Runs when the server returns a 401 response
-  * `onInternalServerError`: Runs when tthe server returns a 500-range response or an ereror is thrown while handling the response from the server.
+  * `onInternalServerError`: Runs when the server returns a 500-range response or an ereror is thrown while handling the response from the server.
 
 Thee callback functions passed in are run after the context provider's own handlers complete. These handlers perform logic as follows:
 

--- a/src/components/game/game.js
+++ b/src/components/game/game.js
@@ -14,7 +14,7 @@ const DESTROY_CONFIRMATION = 'Are you sure you want to delete this game? This ca
 const Game = ({ gameId, name, description }) => {
   const [toggleEvent, setToggleEvent] = useState(0)
 
-  const { hideFlash } = useAppContext()
+  const { displayFlash, hideFlash } = useAppContext()
   const {
     performGameDestroy,
     setGameEditFormVisible,
@@ -52,6 +52,8 @@ const Game = ({ gameId, name, description }) => {
       }
 
       performGameDestroy(gameId, callbacks)
+    } else {
+      displayFlash('info', 'Your game was not deleted')
     }
   }
 

--- a/src/components/game/game.js
+++ b/src/components/game/game.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
-import classNames from 'classnames'
 import SlideToggle from 'react-slide-toggle'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
@@ -71,7 +70,7 @@ const Game = ({ gameId, name, description }) => {
             onClick={destroyGame}
             data-testid={`destroy-icon-game-id-${gameId}`}
           >
-            <FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon)} icon={faTimes} />
+            <FontAwesomeIcon className={styles.fa} icon={faTimes} />
           </button>
           <button
             ref={editRef}

--- a/src/components/game/game.js
+++ b/src/components/game/game.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import SlideToggle from 'react-slide-toggle'
@@ -9,13 +9,19 @@ import { useAppContext, useGamesContext } from '../../hooks/contexts'
 import styles from './game.module.css'
 
 const DEFAULT_DESCRIPTION = 'This game has no description.'
+const DESTROY_CONFIRMATION = 'Are you sure you want to delete this game? This cannot be undone. You will lose all data associated with the game you delete.'
 
 const Game = ({ gameId, name, description }) => {
   const [toggleEvent, setToggleEvent] = useState(0)
 
   const { hideFlash } = useAppContext()
-  const { setGameEditFormVisible, setGameEditFormProps } = useGamesContext()
+  const {
+    performGameDestroy,
+    setGameEditFormVisible,
+    setGameEditFormProps
+  } = useGamesContext()
 
+  const mountedRef = useRef(true)
   const iconsRef = useRef(null)
   const editRef = useRef(null)
   const destroyRef = useRef(null)
@@ -37,7 +43,21 @@ const Game = ({ gameId, name, description }) => {
     setGameEditFormVisible(true)
   }
 
-  const destroyGame = e => {}
+  const destroyGame = e => {
+    const confirmed = window.confirm(DESTROY_CONFIRMATION)
+
+    if (confirmed) {
+      const callbacks = {
+        onSuccess: () => mountedRef.current = false
+      }
+
+      performGameDestroy(gameId, callbacks)
+    }
+  }
+
+  useEffect(() => (
+    mountedRef.current = false
+  ), [])
 
   return(
     <div className={styles.root}>

--- a/src/components/game/game.js
+++ b/src/components/game/game.js
@@ -53,7 +53,7 @@ const Game = ({ gameId, name, description }) => {
 
       performGameDestroy(gameId, callbacks)
     } else {
-      displayFlash('info', 'Your game was not deleted')
+      displayFlash('info', 'Your game was not deleted.')
     }
   }
 

--- a/src/components/game/game.js
+++ b/src/components/game/game.js
@@ -1,8 +1,10 @@
 import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 import SlideToggle from 'react-slide-toggle'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { useAppContext, useGamesContext } from '../../hooks/contexts'
 import styles from './game.module.css'
 
@@ -16,6 +18,7 @@ const Game = ({ gameId, name, description }) => {
 
   const iconsRef = useRef(null)
   const editRef = useRef(null)
+  const destroyRef = useRef(null)
 
   const refContains = (ref, el) => ref.current && (ref.current === el || ref.current.contains(el))
 
@@ -34,10 +37,20 @@ const Game = ({ gameId, name, description }) => {
     setGameEditFormVisible(true)
   }
 
+  const destroyGame = e => {}
+
   return(
     <div className={styles.root}>
       <div className={styles.header} onClick={toggleDescription}>
         <span ref={iconsRef} className={styles.editIcons}>
+          <button
+            ref={destroyRef}
+            className={styles.icon}
+            onClick={destroyGame}
+            data-testid={`destroy-icon-game-id-${gameId}`}
+          >
+            <FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon)} icon={faTimes} />
+          </button>
           <button
             ref={editRef}
             className={styles.icon}

--- a/src/components/gameCreateForm/gameCreateForm.module.css
+++ b/src/components/gameCreateForm/gameCreateForm.module.css
@@ -68,11 +68,6 @@
 }
 
 @media (min-width: 601px) {
-  .root {
-    max-width: 90%;
-    margin: unset;
-  }
-
   .fieldset {
     max-width: 80%;
   }
@@ -81,6 +76,7 @@
 @media (min-width: 769px) {
   .root {
     max-width: 75%;
+    margin: unset;
   }
 
   .fieldset {

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -144,8 +144,7 @@ const ShoppingListItem = ({
         <span className={classNames(styles.header, { [styles.headerEditable]: canEdit })}>
           {canEdit &&
             <span className={styles.editIcons} ref={iconsRef}>
-              <button className={styles.icon} ref={deleteRef} onClick={destroyItem}><FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon
-              )} icon={faTimes} /></button>
+              <button className={styles.icon} ref={deleteRef} onClick={destroyItem}><FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon)} icon={faTimes} /></button>
               <button className={styles.icon} ref={editRef} onClick={showEditForm}><FontAwesomeIcon className={styles.fa} icon={faEdit} /></button>
             </span>}
           <h4 className={styles.description}>{description}</h4>

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -205,7 +205,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           onInternalServerError && onInternalServerError()
         }
       })
-  }, [token, games, logOutAndRedirect])
+  }, [token, games, logOutAndRedirect, displayFlash])
 
   const value = {
     games,

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -174,11 +174,11 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
   }, [token, games, displayFlash, logOutAndRedirect, allErrorsAreValidationErrors])
 
   const performGameDestroy = useCallback((gameId, callbacks) => {
-    const { onSuccess, onNotFound, onUnauthorized, onInternalServerError } = callbacks
+    const { onSuccess, onUnauthorized, onInternalServerError } = callbacks
 
     destroyGame(token, gameId)
       .then(resp => {
-        if (resp.status === 204 && mountedRef.current) {
+        if ((resp.status === 204 || resp.status === 404) && mountedRef.current) {
           const destroyedGame = games.find(game => parseInt(game.id) === parseInt(gameId))
           const gameIndex = games.indexOf(destroyedGame)
 

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -188,6 +188,8 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           setGames(newGames)
 
           onSuccess && onSuccess()
+        } else if (mountedRef.current) {
+          throw new Error(`Something went wrong destroying game ${gameId}`)
         }
       })
       .catch(err => {
@@ -195,6 +197,10 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           logOutAndRedirect(paths.login, () => mountedRef.current = false)
 
           onUnauthorized && onUnauthorized()
+        } else {
+          if (process.env.NODE_ENV === 'development') console.error('Error destroying game: ', err)
+
+          displayFlash('error', "There was an unexpected error deleting your game. Unfortunately, we don't know more than that yet. We're working on it!")
         }
       })
   }, [token, games, logOutAndRedirect])

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -201,6 +201,8 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           if (process.env.NODE_ENV === 'development') console.error('Error destroying game: ', err)
 
           displayFlash('error', "There was an unexpected error deleting your game. Unfortunately, we don't know more than that yet. We're working on it!")
+
+          onInternalServerError && onInternalServerError()
         }
       })
   }, [token, games, logOutAndRedirect])

--- a/src/pages/gamesPage/gamesPage.module.css
+++ b/src/pages/gamesPage/gamesPage.module.css
@@ -27,13 +27,6 @@
   margin: 0 auto;
 }
 
-@media (min-width: 601px) {
-  .games {
-    max-width: 90%;
-    margin: unset;
-  }
-}
-
 @media (min-width: 769px) {
   .noGames {
     font-size: 1.125rem;
@@ -41,6 +34,7 @@
 
   .games {
     max-width: 75%;
+    margin: unset
   }
 }
 

--- a/src/pages/gamesPage/gamesPage.test.js
+++ b/src/pages/gamesPage/gamesPage.test.js
@@ -712,7 +712,7 @@ describe('GamesPage', () => {
         beforeEach(() => {
           server.resetHandlers()
 
-          // For these tests, the user will click "OK" each time
+          // For these tests, the user will click "Cancel" each time
           // they are asked.
           confirm = jest.spyOn(window, 'confirm').mockImplementation(() => false)
         })

--- a/src/pages/gamesPage/gamesPage.test.js
+++ b/src/pages/gamesPage/gamesPage.test.js
@@ -666,7 +666,7 @@ describe('GamesPage', () => {
 
           const destroyIcon = await screen.findByTestId(`destroy-icon-game-id-${games[0].id  }`)
 
-          // Display the edit form
+          // Click the icon
           act(() => {
             fireEvent.click(destroyIcon)
             return undefined;
@@ -681,7 +681,7 @@ describe('GamesPage', () => {
           const game = await screen.findByText(games[0].name)
           const destroyIcon = await screen.findByTestId(`destroy-icon-game-id-${games[0].id  }`)
 
-          // Display the edit form
+          // Click the icon
           act(() => {
             fireEvent.click(destroyIcon)
             return undefined;
@@ -724,7 +724,7 @@ describe('GamesPage', () => {
 
           const destroyIcon = await screen.findByTestId(`destroy-icon-game-id-${games[0].id  }`)
 
-          // Display the edit form
+          // Click the icon
           act(() => {
             fireEvent.click(destroyIcon)
             return undefined;
@@ -739,7 +739,7 @@ describe('GamesPage', () => {
           const game = await screen.findByText(games[0].name)
           const destroyIcon = await screen.findByTestId(`destroy-icon-game-id-${games[0].id  }`)
 
-          // Display the edit form
+          // Click the icon
           act(() => {
             fireEvent.click(destroyIcon)
             return undefined;
@@ -837,7 +837,7 @@ describe('GamesPage', () => {
           const game = await screen.findByText(games[0].name)
           const destroyIcon = await screen.findByTestId(`destroy-icon-game-id-${games[0].id  }`)
 
-          // Display the edit form
+          // Click the icon
           act(() => {
             fireEvent.click(destroyIcon)
             return undefined;

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -95,6 +95,7 @@ export const createGame = (token, attrs) => {
   })
 }
 
+// PATCH /games/:id
 export const updateGame = (token, gameId, attrs) => {
   const uri = `${backendBaseUri}/games/${gameId}`
   const body = JSON.stringify({ game: attrs })
@@ -103,6 +104,21 @@ export const updateGame = (token, gameId, attrs) => {
     method: 'PATCH',
     headers: combinedHeaders(token),
     body: body
+  })
+  .then(resp => {
+    if (resp.status === 401) throw new AuthorizationError()
+    if (resp.status === 404) throw new NotFoundError()
+    return resp
+  })
+}
+
+// DELETE /games/:id
+export const destroyGame = (token, gameId) => {
+  const uri = `${backendBaseUri}/games/${gameId}`
+
+  return fetch(uri, {
+    method: 'DELETE',
+    headers: authHeader(token)
   })
   .then(resp => {
     if (resp.status === 401) throw new AuthorizationError()

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -122,7 +122,6 @@ export const destroyGame = (token, gameId) => {
   })
   .then(resp => {
     if (resp.status === 401) throw new AuthorizationError()
-    if (resp.status === 404) throw new NotFoundError()
     return resp
   })
 }

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -121,6 +121,11 @@ export const destroyGame = (token, gameId) => {
     headers: authHeader(token)
   })
   .then(resp => {
+    // I deviated from the usual pattern of throwing a NotFoundError here
+    // on 404 since the behaviour for 404s is the same as the behaviour for
+    // successful deletion of the game, and making it throw an error here
+    // would just mean duplicating all thatlogic in the handlers in the
+    // GamesProvider.
     if (resp.status === 401) throw new AuthorizationError()
     return resp
   })


### PR DESCRIPTION
## Context

[**Enable users to destroy games from the front end**](https://trello.com/c/56HVhkyy/107-enable-users-to-destroy-games-from-the-front-end)

We've added a new resource, `games`, on the back end, and have added all the functionality for managing them to the UI except the ability to destroy them.

## Changes

* Add destroy icon to Game view
* Add `destroyGame` function to `simApi` module
* Add `performGameDestroy` function to the `GamesProvider` to handle the API response
* Add Jest tests for new functionality
* Add Storybook stories for this (as well as some that should've been added for edit functionality, oops)

## Considerations

On 404 error, our other resources show a flash error message saying they need to refresh the page. I realised that, on a `DELETE` request, this doesn't make much sense - the user wanted the thing gone and, one way or the other, it's gone, so it's better to just remove it from the UI. I've added a [card](https://trello.com/c/ijLLz5c1/120-remove-resources-following-404-responses-for-deletions) to the Trello board to change other resources to do this too.

## Manual Test Cases

Testing handling of 404 and 500 errors will involve programming the API `GamesController::DestroyService`) to always return those errors.

All test cases assume you are logged in, on your Games page and have created some games to test with.

### Happy Path

1. Click the X to the left of one of your games
2. See that you are prompted whether you want to delete it; make sure the message tells the user that (1) the action cannot be undone and (2) they will lose all data associated with the game they destroy
3. Click "OK"
4. See that the game is removed from the list
5. See that the position of the other games on the list relative to each other has not changed

### Happy Path - Cancelled Deletion

1. Click the X to the left of one of your games
2. Click "Cancel" when prompted
3. See that the game is still in the UI where it was before
4. See that there is a flash "info" message indicating that the game was not deleted

### 404 Error

First, program your development API to always return a 404 error for the `GamesController#destroy` route. You can add the following line to `GamesController::DestroyService`, on the first line of the `#perform` method and save:
```ruby
raise ActiveRecord::RecordNotFound
```

1. Click the X to the left of one of your games
2. Click "OK" when prompted
3. See that the game is removed from the UI
4. See that there is no error message on the page or in the console

### 500-Range Error

First, program your development API to always return a 500 error for the `GamesController#destroy` route. You can add the following line to `GamesController::DestroyService`, on the first line of the `#perform` method and save:
```ruby
raise StandardError.new
```

1. Click the X to the left of one of your games
2. Click "OK" when prompted
3. See that the game is not removed from the UI
4. See that there is a flash error message on the page

## Screenshots and GIFs

### 500 Error

#### 1201px

![issue-107_500-error_1201px](https://user-images.githubusercontent.com/5115928/126264969-29590136-d2b2-402e-b442-ba4eeb1279a6.png)

#### 1025px

![issue-107_500-error_1025px](https://user-images.githubusercontent.com/5115928/126264981-39ec85fb-82e5-4bf5-9167-3f8ae76fc7f0.png)

#### 769px

![issue-107_500-error_769px](https://user-images.githubusercontent.com/5115928/126264998-3dd593f3-c4b8-4694-8bf7-4b03c6ef7904.png)

#### 601px

![issue-107_c500-error_601px](https://user-images.githubusercontent.com/5115928/126265719-1216b06e-5966-4d6c-8da4-2c7a9d27db34.png)

#### 425px

![issue-107_500-error_425px](https://user-images.githubusercontent.com/5115928/126265042-c62897c7-7902-4572-b06f-bbdb725c22fc.png)

### Cancelled

#### 1201px

![issue-107_cancelled_1201px](https://user-images.githubusercontent.com/5115928/126265077-98f4848f-ee9e-447d-b0ad-6f4f2dd9ca6f.png)

#### 1025px

![issue-107_cancelled_1025px](https://user-images.githubusercontent.com/5115928/126265092-3176b1ad-e02f-460f-924d-54b070d08a5e.png)

####  769px

![issue-107_cancelled_769px](https://user-images.githubusercontent.com/5115928/126265099-2b461655-731b-4450-b504-21bd2a84d572.png)

#### 601px

![issue-107_c5ancelled_601px](https://user-images.githubusercontent.com/5115928/126265794-114faede-536b-4022-b95d-0e51d6576ed2.png)

#### 425px

![issue-107_cancelled_425px](https://user-images.githubusercontent.com/5115928/126265120-5e5f3d8b-6b38-4e22-a0b3-9109ea4fdce1.png)
