### PR TITLE
Update Storybook stories to show editing and deletion behaviour for games

### DIFF
--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -141,6 +141,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
         } else if (data && data.errors) {
           if (allErrorsAreValidationErrors(data.errors)) {
             displayFlash('error', data.errors, `${data.errors.length} error(s) prevented your game from being updated:`)
+            setGameEditFormVisible(false)
             onUnprocessableEntity && onUnprocessableEntity()
           } else {
             // Something unexpected happened and we don't know what

--- a/src/pages/gamesPage/gamesPage.stories.js
+++ b/src/pages/gamesPage/gamesPage.stories.js
@@ -164,6 +164,99 @@ NotFound.parameters = {
 
 /*
  *
+ * When creating or updating a game returns a 422 (note: the errors returned from the
+ * API for this story are hardcoded, so you will not see the same validation errors that
+ * would actually occur in production)
+ *
+ */
+
+export const UnprocessableEntity = () => (
+  <AppProvider overrideValue={appContextOverrideValue}>
+    <GamesProvider overrideValue={{ gameLoadingState: 'done', games }}>
+      <GamesPage />
+    </GamesProvider>
+  </AppProvider>
+)
+
+UnprocessableEntity.parameters = {
+  msw: [
+    rest.post(`${backendBaseUri}/games`, (req, res, ctx) => {
+      return res(
+        ctx.status(422),
+        ctx.json({
+          errors: [
+            'Name must be unique',
+            "Name can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
+          ]
+        })
+      )
+    }),
+    rest.patch(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(422),
+        ctx.json({
+          errors: [
+            'Name must be unique',
+            "Name can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
+          ]
+        })
+      )
+    }),
+    rest.delete(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(204)
+      )
+    })
+  ]
+}
+
+/*
+ *
+ * When creating, updating, or destroying a game returns a 500 error
+ *
+ */
+
+export const InternalServerError = () => (
+  <AppProvider overrideValue={appContextOverrideValue}>
+    <GamesProvider overrideValue={{ gameLoadingState: 'done', games }}>
+      <GamesPage />
+    </GamesProvider>
+  </AppProvider>
+)
+
+InternalServerError.parameters = {
+  msw: [
+    rest.post(`${backendBaseUri}/games`, (req, res, ctx) => {
+      return res(
+        ctx.status(500),
+        ctx.json({
+          errors: ['Something went horribly wrong']
+        })
+      )
+    }),
+    rest.patch(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(500),
+        ctx.json({
+          errors: ['Something went horribly wrong']
+        })
+      )
+    }),
+    rest.delete(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(500),
+        ctx.json({
+          errors: ['Something went horribly wrong']
+        })
+      )
+    })
+  ]
+}
+
+
+
+/*
+ *
  * When the games are loading
  *
  */

--- a/src/pages/gamesPage/gamesPage.stories.js
+++ b/src/pages/gamesPage/gamesPage.stories.js
@@ -74,7 +74,7 @@ HappyPath.parameters = {
  * 
  */
 
-export const Empty = () => (
+export const HappyPathEmpty = () => (
   <AppProvider overrideValue={appContextOverrideValue}>
     <GamesProvider overrideValue={{ gameLoadingState: 'done', games: emptyGames }}>
       <GamesPage />
@@ -82,12 +82,40 @@ export const Empty = () => (
   </AppProvider>
 )
 
-Empty.parameters = {
+HappyPathEmpty.parameters = {
   msw: [
     rest.get(`${backendBaseUri}/games`, (req, res, ctx) => {
       return res(
         ctx.status(200),
         ctx.json(emptyGames)
+      )
+    }),
+    rest.post(`${backendBaseUri}/games`, (req, res, ctx) => {
+      const name = req.body.game.name
+      const description = req.body.game.description
+
+      const body = { name, description, id: Math.floor(Math.random() * 10000 + 1), user_id: profileData.id }
+
+      return res(
+        ctx.status(201),
+        ctx.json(body)
+      )
+    }),
+    rest.patch(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      const gameId = parseInt(req.params.id)
+      const name = req.body.game.name
+      const description = req.body.game.description
+
+      const body = { name, description, id: gameId, user_id: profileData.id }
+
+      return res(
+        ctx.status(200),
+        ctx.json(body)
+      )
+    }),
+    rest.delete(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(204)
       )
     })
   ]

--- a/src/pages/gamesPage/gamesPage.stories.js
+++ b/src/pages/gamesPage/gamesPage.stories.js
@@ -36,6 +36,34 @@ HappyPath.parameters = {
         ctx.status(200),
         ctx.json(games)
       )
+    }),
+    rest.post(`${backendBaseUri}/games`, (req, res, ctx) => {
+      const name = req.body.game.name
+      const description = req.body.game.description
+
+      const body = { name, description, id: Math.floor(Math.random() * 10000 + 1), user_id: profileData.id }
+
+      return res(
+        ctx.status(201),
+        ctx.json(body)
+      )
+    }),
+    rest.patch(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      const gameId = parseInt(req.params.id)
+      const name = req.body.game.name
+      const description = req.body.game.description
+
+      const body = { name, description, id: gameId, user_id: profileData.id }
+
+      return res(
+        ctx.status(200),
+        ctx.json(body)
+      )
+    }),
+    rest.delete(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(204)
+      )
     })
   ]
 }

--- a/src/pages/gamesPage/gamesPage.stories.js
+++ b/src/pages/gamesPage/gamesPage.stories.js
@@ -123,6 +123,47 @@ HappyPathEmpty.parameters = {
 
 /*
  *
+ * Shows component behaviour when API calls (other than initial fetch) lead to
+ * 404 errors
+ *
+ */
+
+export const NotFound = () => (
+  <AppProvider overrideValue={appContextOverrideValue}>
+    <GamesProvider overrideValue={{ gameLoadingState: 'done', games }}>
+      <GamesPage />
+    </GamesProvider>
+  </AppProvider>
+)
+
+NotFound.parameters = {
+  msw: [
+    rest.post(`${backendBaseUri}/games`, (req, res, ctx) => {
+      const name = req.body.game.name
+      const description = req.body.game.description
+
+      const body = { name, description, id: Math.floor(Math.random() * 10000 + 1), user_id: profileData.id }
+
+      return res(
+        ctx.status(201),
+        ctx.json(body)
+      )
+    }),
+    rest.patch(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(404)
+      )
+    }),
+    rest.delete(`${backendBaseUri}/games/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(404)
+      )
+    })
+  ]
+}
+
+/*
+ *
  * When the games are loading
  *
  */
@@ -138,7 +179,7 @@ export const Loading = () => (
 /*
  *
  * When the server returns a 500 error or another unexpected
- * error is raised
+ * error is raised when fetching games
  *
  */
 

--- a/src/pages/gamesPage/gamesPage.stories.js
+++ b/src/pages/gamesPage/gamesPage.stories.js
@@ -253,8 +253,6 @@ InternalServerError.parameters = {
   ]
 }
 
-
-
 /*
  *
  * When the games are loading

--- a/src/pages/gamesPage/gamesPage.test.js
+++ b/src/pages/gamesPage/gamesPage.test.js
@@ -561,7 +561,7 @@ describe('GamesPage', () => {
           const gamesWithNewName = await screen.queryAllByText(games[1].name)
 
           expect(flashError).toBeVisible()
-          expect(form).toBeVisible()
+          expect(form).not.toBeVisible()
           expect(gameWithOldName).toBeVisible()
           expect(gamesWithNewName.length).toEqual(1)
         })


### PR DESCRIPTION
## Context

[**Enable users to destroy games from the front end**](https://trello.com/c/56HVhkyy/107-enable-users-to-destroy-games-from-the-front-end)
[**Enable users to edit game names and descriptions from the front end**](https://trello.com/c/Aricr2K0/106-enable-users-to-edit-game-names-and-descriptions-from-the-front-end)

In the previous two cards, I forgot to update the stories to illustrate new functionality. This was especially bad given that it wasn't that hard to add mock API calls.

## Changes

* Add Storybook stories for editing and deleting games with different response statuses
* Fix bug (actually expected, and tested, behaviour that was just poorly thought through) where edit form continued to be visible when game was updated with invalid attributes

## Considerations

Having the edit form present when the request returns a 422 error prevents the user from seeing the flash message component with the validation errors. I'd rather have the form stay up so they can fill it out with different attributes but it's better to at least see the errors instead of just wondering why it won't submit or do anything. 

## Manual Test Cases

To test that the edit form is removed on a 422 response, go to your Games page and edit one of your games to have the same name as an existing one (or program your API to always return a 422 error with the right error messages). Submit the form. See that the form is hidden and the flash message component with the validation error is visible.
