### PR TITLE
Fix styling of games page when user has no games

### DIFF
--- a/src/components/game/game.module.css
+++ b/src/components/game/game.module.css
@@ -4,6 +4,10 @@
   border-bottom: 1px solid #ccc;
 }
 
+.root:first-of-type {
+  border-top: 1px solid #ccc;
+}
+
 .header {
   display: flex;
   align-items: flex-start;

--- a/src/components/gameCreateForm/gameCreateForm.module.css
+++ b/src/components/gameCreateForm/gameCreateForm.module.css
@@ -1,7 +1,6 @@
 .root {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
   font-size: 1.025rem;
-  border-bottom: 1px solid #ccc;
   margin-bottom: 32px;
   margin: 0 auto;
 }

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -45,8 +45,8 @@ const GamesPage = () => {
       <div className={styles.root}>
         {flashVisible && <FlashMessage {...flashProps} />}
         {gameEditFormVisible && <div className={styles.overlay} onClick={hideForm}><GameEditForm elementRef={formRef} {...gameEditFormProps} /></div>}
-        <GameCreateForm disabled={gameLoadingState === LOADING || gameLoadingState === ERROR} />
         {games && games.length === 0 && gameLoadingState === DONE && <p className={styles.noGames}>You have no games.</p>}
+        <GameCreateForm disabled={gameLoadingState === LOADING || gameLoadingState === ERROR} />
         {games && games.length > 0 && gameLoadingState === DONE && <div className={styles.games}>
           {games.map(({ id, name, description }) => <Game key={name} gameId={id} name={name} description={description} />)}
         </div>}

--- a/src/pages/gamesPage/gamesPage.module.css
+++ b/src/pages/gamesPage/gamesPage.module.css
@@ -14,9 +14,8 @@
 }
 
 .noGames {
-  font-size: 1.025rem;
-  margin: 0 auto;
-  text-align: center;
+  font-size: 1.15rem;
+  font-weight: 700;
 }
 
 .games {
@@ -28,10 +27,6 @@
 }
 
 @media (min-width: 769px) {
-  .noGames {
-    font-size: 1.125rem;
-  }
-
   .games {
     max-width: 75%;
     margin: unset


### PR DESCRIPTION
## Context

[**Fix styling of games page when user has no games**](https://trello.com/c/N0Er5oVU/119-fix-styling-of-games-page-when-user-has-no-games)

The games page was looking a little weird when the user had no games - there was an awkward bottom border on the create form component (which is collapsed initially) and on narrower screens this border touched the "You have no games" text. This PR fixes the visual there.

## Changes

* Move "You have no games" above the create form and align it left
* Make the top `Game` component (`:first-of-type`) have an upper border instead of the form having a lower border

## Considerations

I tested this out to see if it made things move around too much when the user creates a game and three animations take place (form slides up, game appears on list, and "You have no games" disappears abruptly) but it turned out to not be too distracting visually - it all happens so fast the eye doesn't really take it all in.

## Screenshots and GIFs

### Without Flash Message

#### 1201px
![issue-119-1201px](https://user-images.githubusercontent.com/5115928/126298356-4ad95dca-71d7-43d0-af37-a60e46031ba5.png)

#### 1025px

![issue-119-1025px](https://user-images.githubusercontent.com/5115928/126298412-0db25006-309a-46dd-af01-39a9a294a41a.png)

#### 769px

![issue-119-769px](https://user-images.githubusercontent.com/5115928/126298462-522c08f8-69de-4cf8-a2e0-c535cfcbaf76.png)

#### 601px

![issue-119-601px](https://user-images.githubusercontent.com/5115928/126298490-2c6f161b-2074-4d8b-9494-861034729b75.png)

#### 425px

![issue-119-425px](https://user-images.githubusercontent.com/5115928/126298525-540b765b-74b4-4494-80ab-9ba292a114d6.png)

### With Flash Error

#### 1201px

![issue-119_error_1201px](https://user-images.githubusercontent.com/5115928/126299108-f1f309b6-d6fa-4f56-858b-acf9edafec50.png)

#### 1025px

![issue-119_error_1025px](https://user-images.githubusercontent.com/5115928/126299219-83dbf4df-17ca-4595-86da-1619e21f109f.png)

#### 769px

![issue-119_error_769px](https://user-images.githubusercontent.com/5115928/126299248-d855f881-d2c7-468a-843b-0f937c399749.png)

#### 601px

![issue-119_error_601px](https://user-images.githubusercontent.com/5115928/126299277-30c642f9-e211-490f-ac91-4d6cce6c7d88.png)

#### 425px

![issue-119_error_425px](https://user-images.githubusercontent.com/5115928/126299318-c7b8288e-d0bb-4072-a2cc-1f8d4d363863.png)
