### PR TITLE
Focus game creation form when it is visible

### DIFF
--- a/src/components/gameCreateForm/gameCreateForm.js
+++ b/src/components/gameCreateForm/gameCreateForm.js
@@ -23,9 +23,7 @@ const GameCreateForm = ({ disabled }) => {
     '--button-hover-color': BLUE.hoverColorLight,
   }
 
-  const toggleForm = () => {
-    if (mountedRef.current) setToggleEvent(Date.now)
-  }
+  const toggleForm = () => mountedRef.current && setToggleEvent(Date.now)
 
   const createGame = e => {
     e.preventDefault()

--- a/src/components/gameCreateForm/gameCreateForm.js
+++ b/src/components/gameCreateForm/gameCreateForm.js
@@ -13,6 +13,7 @@ const GameCreateForm = ({ disabled }) => {
   const [toggleEvent, setToggleEvent] = useState(0)
 
   const formRef = useRef(null)
+  const inputRef = useRef(null)
   const mountedRef = useRef(true)
 
   const colorVars = {
@@ -22,7 +23,9 @@ const GameCreateForm = ({ disabled }) => {
     '--button-hover-color': BLUE.hoverColorLight,
   }
 
-  const toggleForm = () => mountedRef.current && setToggleEvent(Date.now)
+  const toggleForm = () => {
+    if (mountedRef.current) setToggleEvent(Date.now)
+  }
 
   const createGame = e => {
     e.preventDefault()
@@ -55,7 +58,7 @@ const GameCreateForm = ({ disabled }) => {
   return(
     <div className={styles.root} style={colorVars}>
       <h3 className={styles.slideToggleTrigger} onClick={toggleForm}>Create Game...</h3>
-      <SlideToggle toggleEvent={toggleEvent} collapsed>
+      <SlideToggle toggleEvent={toggleEvent} onExpanded={() => inputRef.current.focus()} collapsed>
         {({ setCollapsibleElement }) => (
           /* Include this div so we can set the form ref to something else */
           <div ref={setCollapsibleElement}>
@@ -63,6 +66,7 @@ const GameCreateForm = ({ disabled }) => {
             <form ref={formRef} className={styles.form} data-testid='game-create-form' onSubmit={createGame}>
               <fieldset className={classNames(styles.fieldset, { [styles.fieldsetDisabled]: disabled })} disabled={disabled}>
                 <input
+                  ref={inputRef}
                   className={styles.input}
                   type='text'
                   name='name'

--- a/src/components/gameCreateForm/gameCreateForm.module.css
+++ b/src/components/gameCreateForm/gameCreateForm.module.css
@@ -97,10 +97,6 @@
 }
 
 @media (min-width: 1201px) {
-  .root {
-    max-width: 50%;
-  }
-
   .fieldset {
     max-width: 50%;
   }

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -46,7 +46,7 @@ const GamesPage = () => {
         {flashVisible && <FlashMessage {...flashProps} />}
         {gameEditFormVisible && <div className={styles.overlay} onClick={hideForm}><GameEditForm elementRef={formRef} {...gameEditFormProps} /></div>}
         {games && games.length === 0 && gameLoadingState === DONE && <p className={styles.noGames}>You have no games.</p>}
-        <GameCreateForm disabled={gameLoadingState === LOADING || gameLoadingState === ERROR} />
+        {gameLoadingState === DONE && <GameCreateForm disabled={gameLoadingState === LOADING || gameLoadingState === ERROR} />}
         {games && games.length > 0 && gameLoadingState === DONE && <div className={styles.games}>
           {games.map(({ id, name, description }) => <Game key={name} gameId={id} name={name} description={description} />)}
         </div>}


### PR DESCRIPTION
## Context

[**Focus game creation form when it is visible**](https://trello.com/c/zXe6QXwv/117-focus-game-creation-form-when-it-is-visible)

When the game creation form becomes visible, it isn't automatically focussed. This PR makes sure the form is focussed when it's expanded.

## Changes

* Focus input in callback on `SlideToggle` component
* Only show the 'Create Form' link when the game loading state is `'done'` to prevent it jumping down when there are no games
* Commit a CSS change I meant to commit in #96

## Considerations

It turns out react-slide-toggle includes a handy `onExpanded` prop that you can use for a callback. This made it super easy to just focus the input when the form was expanded.

## Manual Test Cases

Just expand the games creation form and check that the first input is focussed when the form expands.
