### PR TITLE
Extract Modal component

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import styles from './modal.module.css'
+
+const Modal = ({ children, ...props }) => {
+
+  return(
+    <div className={styles.root} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export default Modal

--- a/src/components/modal/modal.module.css
+++ b/src/components/modal/modal.module.css
@@ -1,0 +1,9 @@
+.root {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  background-color: rgba(0,0,0,0.5);
+  z-index: 1000;
+}

--- a/src/components/modal/modal.stories.js
+++ b/src/components/modal/modal.stories.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import Modal from './modal'
+
+const containerStyles = {
+  fontFamily: "'Quattrocento Sans', Arial, Helvetica, sans-serif",
+  position: 'relative',
+  top: '50%',
+  transform: 'translateY(-50%)',
+  margin: 'auto',
+  height: '64px',
+  padding: '8px',
+  backgroundColor: '#fff',
+  textAlign: 'center',
+  display: 'grid',
+  maxWidth: '80%'
+}
+
+const contentStyles = {
+  margin: 'auto',
+  textAlign: 'center'
+}
+
+export default { title: 'Modal' }
+
+export const Default = () => (
+  <Modal>
+    <div style={containerStyles}>
+      <p style={contentStyles}>This is the modal content</p>
+    </div>
+  </Modal>
+)

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -8,6 +8,7 @@ import Game from '../../components/game/game'
 import GameCreateForm from '../../components/gameCreateForm/gameCreateForm'
 import GameEditForm from '../../components/gameEditForm/gameEditForm'
 import Loading from '../../components/loading/loading'
+import Modal from '../../components/modal/modal'
 import styles from './gamesPage.module.css'
 
 const { LOADING, DONE, ERROR } = gameLoadingStates
@@ -44,7 +45,7 @@ const GamesPage = () => {
     <DashboardLayout title='Your Games'>
       <div className={styles.root}>
         {flashVisible && <FlashMessage {...flashProps} />}
-        {gameEditFormVisible && <div className={styles.overlay} onClick={hideForm}><GameEditForm elementRef={formRef} {...gameEditFormProps} /></div>}
+        {gameEditFormVisible && <Modal onClick={hideForm}><GameEditForm elementRef={formRef} {...gameEditFormProps} /></Modal>}
         {games && games.length === 0 && gameLoadingState === DONE && <p className={styles.noGames}>You have no games.</p>}
         {gameLoadingState === DONE && <GameCreateForm disabled={gameLoadingState === LOADING || gameLoadingState === ERROR} />}
         {games && games.length > 0 && gameLoadingState === DONE && <div className={styles.games}>

--- a/src/pages/gamesPage/gamesPage.module.css
+++ b/src/pages/gamesPage/gamesPage.module.css
@@ -3,16 +3,6 @@
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
 }
 
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  background-color: rgba(0,0,0,0.5);
-  z-index: 1000;
-}
-
 .noGames {
   font-size: 1.15rem;
   font-weight: 700;

--- a/src/pages/shoppingListPage/shoppingListPage.js
+++ b/src/pages/shoppingListPage/shoppingListPage.js
@@ -3,6 +3,7 @@ import { useAppContext, useShoppingListContext } from '../../hooks/contexts'
 import { shoppingListLoadingStates } from '../../contexts/shoppingListContext'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
+import Modal from '../../components/modal/modal'
 import ShoppingListCreateForm from '../../components/shoppingListCreateForm/shoppingListCreateForm'
 import ShoppingListPageContent from '../../components/shoppingListPageContent/shoppingListPageContent'
 import styles from './shoppingListPage.module.css'
@@ -39,7 +40,7 @@ const ShoppingListPage = () => {
 
   return(
     <DashboardLayout title='Your Shopping Lists'>
-      {listItemEditFormVisible && <div className={styles.overlay} onClick={hideForm}><ShoppingListItemEditForm elementRef={formRef} {...listItemEditFormProps} /></div>}
+      {listItemEditFormVisible && <Modal onClick={hideForm}><ShoppingListItemEditForm elementRef={formRef} {...listItemEditFormProps} /></Modal>}
       {flashVisible && <div className={styles.flash}><FlashMessage {...flashProps} /></div>}
       <div className={styles.createForm}><ShoppingListCreateForm disabled={shouldDisableForm} /></div>
       <ShoppingListPageContent /> {/* This component implements its own loading & error handling behaviour */}


### PR DESCRIPTION
## Context

[**Extract Modal component**](https://trello.com/c/8oicbfBt/118-extract-modal-component)

In a couple places, we use a modal to display a form. We'd like to eventually make the `AppContext` responsible for knowing when the modal should be open or closed. This first PR extracts a component. The next PR will move responsibility for the component to the `AppProvider`.

## Changes

* Extract "overlay" divs into `Modal` component
* Add Storybook story for modal

## Considerations

~~Currently, this new implementation doesn't work yet - it has reenabled scrolling when the modal is open.~~ This was only the case in Storybook because its `window` situation is weird.

## Manual Test Cases

Just make sure you can show and hide the game edit form. There should be no visible changes.