### PR TITLE
Select active game from dropdown

### DIFF
--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -91,7 +91,7 @@ const GamesDropdown = () => {
   }, [games, setActiveGame, activeGame, setInputValue, inputValue, history, collapseDropdown])
 
   return(
-    <div ref={componentRef} className={styles.root} style={colorVars}>
+    <div ref={componentRef} className={styles.root} style={colorVars} data-testid='games-dropdown'>
       <div
         className={styles.header}
         role='combobox'
@@ -132,6 +132,7 @@ const GamesDropdown = () => {
           ref={buttonRef}
           className={styles.trigger}
           onClick={toggleDropdown}
+          data-testid='games-dropdown-trigger'
         >
           <FontAwesomeIcon className={styles.fa} icon={faAngleDown} />
         </button>

--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -1,3 +1,12 @@
+/*
+ * It was important to have a styled options list, so a native HTML select
+ * dropdown wouldn't do. This component has been made to be as accessible as
+ * possible, adhering to the ARIA specification for comboboxes. More information
+ * on comboboxes and their expected behaviour can be found in the ARIA docs:
+ * https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html
+ *
+ */
+
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import classNames from 'classnames'
 import { useHistory } from 'react-router-dom'

--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -162,12 +162,12 @@ const GamesDropdown = () => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   selectGame({ id, name })
                 } else if (e.key === 'ArrowUp') {
-                  // e.preventDefault()
+                  e.preventDefault()
                   const focusables = [...document.getElementsByClassName('focusable')]
                   const index = focusables.indexOf(e.target)
                   focusables[index - 1].focus()
                 } else if (e.key === 'ArrowDown') {
-                  // e.preventDefault()
+                  e.preventDefault()
                   const focusables = [...document.getElementsByClassName('focusable')]
                   const index = focusables.indexOf(e.target)
                   const nextIndex = index < focusables.length - 1 ? index + 1 : 0

--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -18,8 +18,6 @@ const GamesDropdown = () => {
   const [inputValue, setInputValue] = useState('')
 
   const componentRef = useRef(null)
-  const inputRef = useRef(null)
-  const buttonRef = useRef(null)
 
   const expandDropdown = () => setDropdownExpanded(true)
   const collapseDropdown = useCallback(() => setDropdownExpanded(false), [setDropdownExpanded])
@@ -101,7 +99,6 @@ const GamesDropdown = () => {
         aria-expanded={dropdownExpanded}
       >
         <input
-          ref={inputRef}
           className={classNames(styles.input, 'focusable')}
           type='text'
           value={inputValue}
@@ -129,7 +126,6 @@ const GamesDropdown = () => {
           }}
         />
         <button
-          ref={buttonRef}
           className={styles.trigger}
           onClick={toggleDropdown}
           onKeyDown={e => {

--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -110,6 +110,7 @@ const GamesDropdown = () => {
         <input
           className={classNames(styles.input, 'focusable')}
           type='text'
+          disabled={!games.length}
           value={inputValue}
           onChange={updateValue}
           placeholder='No games available'
@@ -143,6 +144,7 @@ const GamesDropdown = () => {
               document.getElementsByClassName('focusable')[1].focus()
             }
           }}
+          disabled={!games.length}
           data-testid='games-dropdown-trigger'
         >
           <FontAwesomeIcon className={styles.fa} icon={faAngleDown} />

--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -5,7 +5,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons'
 import { BLUE } from '../../utils/colorSchemes'
 import { useGamesContext } from '../../hooks/contexts'
-import useQuery from '../../hooks/useQuery'
 import GamesDropdownOption from '../gamesDropdownOption/gamesDropdownOption'
 import styles from './gamesDropdown.module.css'
 
@@ -15,7 +14,6 @@ const GamesDropdown = () => {
   const { games } = useGamesContext()
 
   const [activeGame, setActiveGame] = useState(null)
-  const [filteredGames, setFilteredGames] = useState(games)
   const [dropdownExpanded, setDropdownExpanded] = useState(false)
   const [inputValue, setInputValue] = useState('')
 
@@ -44,27 +42,13 @@ const GamesDropdown = () => {
     collapseDropdown()
   }, [history, collapseDropdown])
 
-  // If the user has typed a string into the input, filter the games to only display
-  // the ones that match what they've typed. 
-  const filterGames = str => {
-    if (str) {
-      const tmpGames = games.filter(game => game.name.toLowerCase().match(new RegExp(str.toLowerCase(),'i')))
-      if (tmpGames.length) setFilteredGames([...tmpGames])
-    } else {
-      setFilteredGames(games)
-    }
-  }
-
   const isActiveGame = id => {
     if (activeGame && !games.length) return false
 
     return activeGame ? activeGame.id === id : id === games[0].id
   }
 
-  const updateValue = e => {
-    setInputValue(e.currentTarget.value)
-    filterGames(e.currentTarget.value)
-  }
+  const updateValue = e => setInputValue(e.currentTarget.value)
 
   useEffect(() => {
     if (!activeGame && games.length) {
@@ -81,7 +65,7 @@ const GamesDropdown = () => {
 
         // Find out if there is a game whose title exactly matches the
         // text typed into the input (without regard to case).
-        const game = filteredGames.find(g => g.name.toLowerCase() === inputValue.toLowerCase())
+        const game = games.find(g => g.name.toLowerCase() === inputValue.toLowerCase())
 
         if (game) {
           // If there is a matching game, it should be selected when the
@@ -104,7 +88,7 @@ const GamesDropdown = () => {
     return () => {
       document.removeEventListener('focusout', collapseDropdownAndResetValue)
     }
-  }, [filteredGames, setActiveGame, activeGame, setInputValue, inputValue, history, collapseDropdown])
+  }, [games, setActiveGame, activeGame, setInputValue, inputValue, history, collapseDropdown])
 
   return(
     <div ref={componentRef} className={styles.root} style={colorVars}>
@@ -133,9 +117,11 @@ const GamesDropdown = () => {
               const game = games.find(g => g.name.toLowerCase() === e.target.value.toLowerCase())
               game && selectGame(game)
             } else if (e.key === 'ArrowUp') {
+              e.preventDefault()
               const focusables = document.getElementsByClassName('focusable')
               focusables[focusables.length - 1].focus()
             } else if (e.key === 'ArrowDown') {
+              e.preventDefault()
               document.getElementsByClassName('focusable')[1].focus()
             } else if (e.key === 'Escape') {
               collapseDropdown()
@@ -152,10 +138,10 @@ const GamesDropdown = () => {
       </div>
       <ul
         id='gamesListbox'
-        className={classNames(styles.dropdown, { [styles.hidden]: !dropdownExpanded || !filteredGames.length })}
+        className={classNames(styles.dropdown, { [styles.hidden]: !dropdownExpanded || !games.length })}
         role='listbox'
       >
-        {filteredGames.map(({ id, name }, index) => {
+        {games.map(({ id, name }, index) => {
           return(
             <GamesDropdownOption
               className='focusable'

--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -1,0 +1,193 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAngleDown } from '@fortawesome/free-solid-svg-icons'
+import { useGamesContext } from '../../hooks/contexts'
+import styles from './gamesDropdown.module.css'
+
+// TODO:
+// - Make focus shift between the list items when you push the arrow
+//   keys (up/down) from the input
+
+const GamesDropdown = ({ onSelectGame, defaultGame = null }) => {
+  const { games } = useGamesContext()
+
+  const [activeGame, setActiveGame] = useState(defaultGame || games[0])
+  const [filteredGames, setFilteredGames] = useState(games)
+  const [dropdownExpanded, setDropdownExpanded] = useState(false)
+  const [inputValue, setInputValue] = useState(activeGame ? activeGame.name : '')
+
+  const componentRef = useRef(null)
+  const inputRef = useRef(null)
+  const buttonRef = useRef(null)
+
+  const expandDropdown = () => setDropdownExpanded(true)
+  const collapseDropdown = useCallback(() => setDropdownExpanded(false), [setDropdownExpanded])
+  const toggleDropdown = () => setDropdownExpanded(!dropdownExpanded)
+
+  const selectGame = (game) => {
+    setActiveGame(game)
+    setInputValue(game.name)
+    onSelectGame(game)
+    collapseDropdown()
+  }
+
+  // If the user has typed a string into the input, filter the games to only display
+  // the ones that match what they've typed. 
+  const filterGames = str => {
+    if (str) {
+      const tmpGames = games.filter(game => game.name.toLowerCase().match(new RegExp(str.toLowerCase(),'i')))
+      setFilteredGames([...tmpGames])
+    } else {
+      setFilteredGames(games)
+    }
+  }
+
+  // When the focus is moved away from the input onto a different element
+  // entirely (and not just onto the button or options), we want to reset
+  // either set the game indicated  
+  const setGameOrResetInputValue = e => {
+    if (componentRef.current.contains(e.relatedTarget)) return
+
+    const game = filteredGames.find(g => g.name.toLowerCase() === inputValue.toLowerCase())
+
+    if (game) {
+      setActiveGame(game).then(() => setInputValue(activeGame.name))
+    } else {
+      setInputValue(activeGame.name)
+    }
+  }
+
+  const isActiveGame = id => {
+    if (activeGame && !games.length) return false
+
+    return activeGame ? activeGame.id === id : id === games[0].id
+  }
+
+  const updateValue = e => {
+    setInputValue(e.currentTarget.value)
+    filterGames(e.currentTarget.value)
+  }
+
+  useEffect(() => {
+    const collapseDropdownWhenClickedOutside = e => {
+      if (componentRef.current !== e.target && !componentRef.current.contains(e.target)) collapseDropdown()
+    }
+
+    const collapseDropdownAndResetValue = e => {
+      if (componentRef.current !== e.relatedTarget && !componentRef.current.contains(e.relatedTarget)) {
+        // Hide the dropdown
+        collapseDropdown()
+
+        // Find out if there is a game whose title exactly matches the
+        // text typed into the input (without regard to case).
+        const game = filteredGames.find(g => g.name.toLowerCase() === inputValue.toLowerCase())
+
+        if (game) {
+          // If there is a matching game, it should be selected when the
+          // component is no longer focussed.
+          setActiveGame(game)
+          setInputValue(game.name)
+          onSelectGame(game)
+        } else {
+          // If there is no matching game, the input value should be reset
+          // to the name of the active game.
+          setInputValue(activeGame.name)
+        }
+      }
+    }
+
+    window.addEventListener('click', collapseDropdownWhenClickedOutside)
+    document.addEventListener('focusout', collapseDropdownAndResetValue)
+
+    return () => {
+      window.removeEventListener('click', collapseDropdownWhenClickedOutside)
+      document.removeEventListener('focusout', collapseDropdownAndResetValue)
+    }
+  }, [filteredGames, setActiveGame, setInputValue, collapseDropdown])
+
+  return(
+    <div ref={componentRef} className={styles.root}>
+      <div
+        className={classNames(styles.header, { [styles.headerExpanded]: dropdownExpanded })}
+        role='combobox'
+        aria-haspopup='listbox'
+        aria-owns='gamesListbox'
+        aria-controls='gamesListbox'
+        aria-expanded={dropdownExpanded}
+      >
+        <input
+          ref={inputRef}
+          className={classNames(styles.input, 'focusable')}
+          type='text'
+          value={inputValue}
+          onChange={updateValue}
+          placeholder='No games available'
+          aria-autocomplete='list'
+          aria-multiline={false}
+          aria-controls='gamesListbox'
+          onFocus={expandDropdown}
+          onClick={expandDropdown}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              const game = games.find(g => g.name === e.target.value)
+              game && selectGame(game)
+            } else if (e.key === 'ArrowUp') {
+              const allFocusables = document.getElementsByClassName('focusable')
+              allFocusables[allFocusables.length - 1].focus()
+            } else if (e.key === 'ArrowDown') {
+              document.getElementsByClassName('focusable')[1].focus()
+            }
+          }}
+        />
+        <button
+          ref={buttonRef}
+          className={styles.trigger}
+          onClick={toggleDropdown}
+        >
+          <FontAwesomeIcon className={styles.fa} icon={faAngleDown} />
+        </button>
+      </div>
+      <ul id='gamesListbox' className={classNames(styles.dropdown, { [styles.hidden]: !dropdownExpanded })} role='listbox'>
+        {filteredGames.map(({ id, name }, index) => {
+          return(
+            <li
+              className={classNames(styles.option, 'focusable')}
+              onClick={() => selectGame({ id, name })}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  selectGame({ id, name })
+                } else if (e.key === 'ArrowUp') {
+                  const focusables = [...document.getElementsByClassName('focusable')]
+                  const index = focusables.indexOf(e.target)
+                  focusables[index - 1].focus()
+                } else if (e.key === 'ArrowDown') {
+                  const focusables = [...document.getElementsByClassName('focusable')]
+                  const index = focusables.indexOf(e.target)
+                  const nextIndex = index < focusables.length - 1 ? index + 1 : 0
+                  focusables[nextIndex].focus()
+                }
+              }}
+              key={`${name.replace(' ', '_')}-${id}`}
+              role='option'
+              aria-selected={isActiveGame(id)}
+              tabIndex={0}
+
+            >{name}</li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+GamesDropdown.propTypes = {
+  onSelectGame: PropTypes.func.isRequired,
+  defaultGame: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired
+  })
+}
+
+export default GamesDropdown

--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -132,6 +132,12 @@ const GamesDropdown = () => {
           ref={buttonRef}
           className={styles.trigger}
           onClick={toggleDropdown}
+          onKeyDown={e => {
+            if (e.key === 'ArrowDown') {
+              e.preventDefault()
+              document.getElementsByClassName('focusable')[1].focus()
+            }
+          }}
           data-testid='games-dropdown-trigger'
         >
           <FontAwesomeIcon className={styles.fa} icon={faAngleDown} />

--- a/src/components/gamesDropdown/gamesDropdown.module.css
+++ b/src/components/gamesDropdown/gamesDropdown.module.css
@@ -1,7 +1,8 @@
 .root {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
-  font-size: 1.025rem;
+  font-size: 1rem;
   padding: 8px;
+  margin: auto 0;
 }
 
 .header {
@@ -13,22 +14,22 @@
 
 .input {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
-  font-size: 1.025rem;
+  font-size: 1rem;
   color: #5f5f5f;
   border: none;
   padding: 8px;
 }
 
 .trigger {
-  background-color: #fff;
+  background-color: var(--button-background-color);
+  color: var(--button-text-color);
   margin: 0;
-  border: none;
-  border-left: 1px solid #5f5f5f;
+  border: 1px solid var(--border-color);
   cursor: pointer;
 }
 
 .trigger:hover {
-  background-color: #f5f5f5;
+  background-color: var(--button-hover-color);
 }
 
 .hidden {
@@ -36,7 +37,10 @@
 }
 
 .dropdown {
+  position: absolute;
+  background-color: #fff;
   width: 100%;
+  max-height: 105px;
   list-style-type: none;
   padding: 0;
   margin: 0;
@@ -44,6 +48,7 @@
   border-top: none;
   border-radius: 3px;
   box-sizing: border-box;
+  overflow-y: scroll;
 }
 
 .option {
@@ -63,10 +68,15 @@
 
 @media (min-width: 769px) {
   .root {
-    font-size: 1.125rem;
+    font-size: 1.025rem;
+    width: 228px;
   }
 
   .input {
-    font-size: 1.125rem;
+    font-size: 1.025rem;
+  }
+
+  .dropdown {
+    width: 228px;
   }
 }

--- a/src/components/gamesDropdown/gamesDropdown.module.css
+++ b/src/components/gamesDropdown/gamesDropdown.module.css
@@ -51,21 +51,6 @@
   width: 228px;
 }
 
-.option {
-  color: #5f5f5f;
-  padding: 8px;
-  border-bottom: 1px solid #e0e0e0;
-  cursor: pointer;
-}
-
-.option:hover {
-  background-color: #f5f5f5;
-}
-
-.option:last-of-type {
-  border-bottom: none;
-}
-
 @media (min-width: 769px) {
   .root {
     font-size: 1.025rem;

--- a/src/components/gamesDropdown/gamesDropdown.module.css
+++ b/src/components/gamesDropdown/gamesDropdown.module.css
@@ -20,6 +20,10 @@
   padding: 8px;
 }
 
+.input:disabled {
+  cursor: not-allowed;
+}
+
 .trigger {
   background-color: var(--button-background-color);
   color: var(--button-text-color);
@@ -31,6 +35,17 @@
 .trigger:hover {
   background-color: var(--button-hover-color);
 }
+
+.trigger:disabled {
+  background-color: #7c8388;
+  border-color: #4b5053;
+  cursor: not-allowed;
+}
+
+.trigger:disabled:hover {
+  background-color: #7c8388;
+}
+
 
 .hidden {
   display: none;

--- a/src/components/gamesDropdown/gamesDropdown.module.css
+++ b/src/components/gamesDropdown/gamesDropdown.module.css
@@ -1,0 +1,72 @@
+.root {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  font-size: 1.025rem;
+  padding: 8px;
+}
+
+.header {
+  border: 1px solid #5f5f5f;
+  border-radius: 3px;
+  display: grid;
+  grid-template-columns: 8fr 1fr;
+}
+
+.input {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  font-size: 1.025rem;
+  color: #5f5f5f;
+  border: none;
+  padding: 8px;
+}
+
+.trigger {
+  background-color: #fff;
+  margin: 0;
+  border: none;
+  border-left: 1px solid #5f5f5f;
+  cursor: pointer;
+}
+
+.trigger:hover {
+  background-color: #f5f5f5;
+}
+
+.hidden {
+  display: none;
+}
+
+.dropdown {
+  width: 100%;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid #5f5f5f;
+  border-top: none;
+  border-radius: 3px;
+  box-sizing: border-box;
+}
+
+.option {
+  color: #5f5f5f;
+  padding: 8px;
+  border-bottom: 1px solid #e0e0e0;
+  cursor: pointer;
+}
+
+.option:hover {
+  background-color: #f5f5f5;
+}
+
+.option:last-of-type {
+  border-bottom: none;
+}
+
+@media (min-width: 769px) {
+  .root {
+    font-size: 1.125rem;
+  }
+
+  .input {
+    font-size: 1.125rem;
+  }
+}

--- a/src/components/gamesDropdown/gamesDropdown.module.css
+++ b/src/components/gamesDropdown/gamesDropdown.module.css
@@ -1,8 +1,8 @@
 .root {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
   font-size: 1rem;
-  padding: 8px;
   margin: auto 0;
+  width: 228px;
 }
 
 .header {
@@ -39,7 +39,6 @@
 .dropdown {
   position: absolute;
   background-color: #fff;
-  width: 100%;
   max-height: 105px;
   list-style-type: none;
   padding: 0;
@@ -49,6 +48,7 @@
   border-radius: 3px;
   box-sizing: border-box;
   overflow-y: scroll;
+  width: 228px;
 }
 
 .option {
@@ -69,14 +69,9 @@
 @media (min-width: 769px) {
   .root {
     font-size: 1.025rem;
-    width: 228px;
   }
 
   .input {
     font-size: 1.025rem;
-  }
-
-  .dropdown {
-    width: 228px;
   }
 }

--- a/src/components/gamesDropdown/gamesDropdown.stories.js
+++ b/src/components/gamesDropdown/gamesDropdown.stories.js
@@ -6,6 +6,13 @@ import GamesDropdown from './gamesDropdown'
 
 export default { title: 'GamesDropdown' }
 
+/*
+ *
+ * When there are a couple of games on the list and all of their
+ * names fit easily
+ *
+ */
+
 export const Default = () => (
   <AppProvider overrideValue={{ token, profileData }}>
     <GamesProvider overrideValue={{ games }}>
@@ -13,6 +20,12 @@ export const Default = () => (
     </GamesProvider>
   </AppProvider>
 )
+
+/*
+ *
+ * When there is a scrollbar inside the dropdown
+ *
+ */
 
 const longGameList = [...games]
 longGameList.push(
@@ -28,6 +41,12 @@ export const WithLongGameList = () => (
     </GamesProvider>
   </AppProvider>
 )
+
+/*
+ *
+ * When there are no games to choose from
+ *
+ */
 
 export const NoGames = () => (
   <AppProvider overrideValue={{ token, profileData }}>

--- a/src/components/gamesDropdown/gamesDropdown.stories.js
+++ b/src/components/gamesDropdown/gamesDropdown.stories.js
@@ -13,3 +13,18 @@ export const Default = () => (
     </GamesProvider>
   </AppProvider>
 )
+
+const longGameList = [...games]
+longGameList.push(
+  { id: 688, user_id: 24, name: 'My Game 3' },
+  { id: 1257, user_id: 24, name: 'My Game 4' },
+  { id: 349, user_id: 24, name: 'My Game 5' }
+)
+
+export const WithLongGameList = () => (
+  <AppProvider overrideValue={{ token, profileData }}>
+    <GamesProvider overrideValue={{ games: longGameList }}>
+      <GamesDropdown />
+    </GamesProvider>
+  </AppProvider>
+)

--- a/src/components/gamesDropdown/gamesDropdown.stories.js
+++ b/src/components/gamesDropdown/gamesDropdown.stories.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { AppProvider } from '../../contexts/appContext'
+import { GamesProvider } from '../../contexts/gamesContext'
+import { token, profileData, games } from '../../sharedTestData'
+import GamesDropdown from './gamesDropdown'
+
+export default { title: 'GamesDropdown' }
+
+export const Default = () => (
+  <AppProvider overrideValue={{ token, profileData }}>
+    <GamesProvider overrideValue={{ games }}>
+      <GamesDropdown onSelectGame={id => { /* noop */ }} />
+    </GamesProvider>
+  </AppProvider>
+)

--- a/src/components/gamesDropdown/gamesDropdown.stories.js
+++ b/src/components/gamesDropdown/gamesDropdown.stories.js
@@ -9,7 +9,7 @@ export default { title: 'GamesDropdown' }
 export const Default = () => (
   <AppProvider overrideValue={{ token, profileData }}>
     <GamesProvider overrideValue={{ games }}>
-      <GamesDropdown onSelectGame={id => { /* noop */ }} />
+      <GamesDropdown />
     </GamesProvider>
   </AppProvider>
 )

--- a/src/components/gamesDropdown/gamesDropdown.stories.js
+++ b/src/components/gamesDropdown/gamesDropdown.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { AppProvider } from '../../contexts/appContext'
 import { GamesProvider } from '../../contexts/gamesContext'
-import { token, profileData, games } from '../../sharedTestData'
+import { token, profileData, emptyGames, games } from '../../sharedTestData'
 import GamesDropdown from './gamesDropdown'
 
 export default { title: 'GamesDropdown' }
@@ -24,6 +24,14 @@ longGameList.push(
 export const WithLongGameList = () => (
   <AppProvider overrideValue={{ token, profileData }}>
     <GamesProvider overrideValue={{ games: longGameList }}>
+      <GamesDropdown />
+    </GamesProvider>
+  </AppProvider>
+)
+
+export const NoGames = () => (
+  <AppProvider overrideValue={{ token, profileData }}>
+    <GamesProvider overrideValue={{ games: emptyGames }}>
       <GamesDropdown />
     </GamesProvider>
   </AppProvider>

--- a/src/components/gamesDropdownOption/gamesDropdownOption.js
+++ b/src/components/gamesDropdownOption/gamesDropdownOption.js
@@ -1,3 +1,14 @@
+/*
+ *
+ * This component is intended for use within the GamesDropdown.
+ * The GamesDropdown mimics a native `select` element. It is
+ * critical that this component's role and ARIA attributes not
+ * be changed except to make it more accessible or fix bugs in
+ * accessibility. If you need a different role or aria attributes,
+ * pass the values in as props or create another component.
+ *
+ */
+
 import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'

--- a/src/components/gamesDropdownOption/gamesDropdownOption.js
+++ b/src/components/gamesDropdownOption/gamesDropdownOption.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import styles from './gamesDropdownOption.module.css'
+
+const GamesDropdownOption = ({
+  name,
+  key,
+  className,
+  onClick,
+  onKeyDown,
+  ariaSelected
+}) => {
+  return(
+    <li
+      className={classNames(styles.root, className)}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      role='option'
+      tabIndex={0}
+      aria-selected={ariaSelected}
+    >
+      {name.length > 24 ? `${name.substring(0, 23)}...` : name}
+    </li>
+  )
+}
+
+GamesDropdownOption.propTypes = {
+  name: PropTypes.string.isRequired,
+  key: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  ariaSelected: PropTypes.bool.isRequired
+}
+
+export default GamesDropdownOption

--- a/src/components/gamesDropdownOption/gamesDropdownOption.js
+++ b/src/components/gamesDropdownOption/gamesDropdownOption.js
@@ -5,7 +5,6 @@ import styles from './gamesDropdownOption.module.css'
 
 const GamesDropdownOption = ({
   name,
-  key,
   className,
   onClick,
   onKeyDown,
@@ -27,7 +26,6 @@ const GamesDropdownOption = ({
 
 GamesDropdownOption.propTypes = {
   name: PropTypes.string.isRequired,
-  key: PropTypes.string.isRequired,
   className: PropTypes.string,
   onClick: PropTypes.func,
   onKeyDown: PropTypes.func,

--- a/src/components/gamesDropdownOption/gamesDropdownOption.module.css
+++ b/src/components/gamesDropdownOption/gamesDropdownOption.module.css
@@ -7,7 +7,7 @@
   cursor: pointer;
 }
 
-.root:hover {
+.root:hover, .root:focus {
   background-color: #f5f5f5;
 }
 

--- a/src/components/gamesDropdownOption/gamesDropdownOption.module.css
+++ b/src/components/gamesDropdownOption/gamesDropdownOption.module.css
@@ -1,0 +1,22 @@
+.root {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  font-size: 1rem;
+  color: #5f5f5f;
+  padding: 8px;
+  border-bottom: 1px solid #e0e0e0;
+  cursor: pointer;
+}
+
+.root:hover {
+  background-color: #f5f5f5;
+}
+
+.root:last-of-type {
+  border-bottom: none;
+}
+
+@media (min-width: 769px) {
+  .root {
+    font-size: 1.025rem;
+  }
+}

--- a/src/components/gamesDropdownOption/gamesDropdownOption.stories.js
+++ b/src/components/gamesDropdownOption/gamesDropdownOption.stories.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import GamesDropdownOption from './gamesDropdownOption'
+
+const Parent = ({ children }) => (
+  <ul style={{ width: '228px', listStyleType: 'none', padding: 0, margin: 0 }}>
+    {children}
+  </ul>
+)
+
+export default { title: 'GamesDropdownOption' }
+
+export const Default = () => (
+  <Parent>
+   <GamesDropdownOption
+    name='My Game 1'
+    key={1}
+    ariaSelected={false}
+  />
+  </Parent>
+)
+
+export const LongName = () => (
+  <Parent>
+    <GamesDropdownOption
+      name='Neque porro quisquam est quis dolorem ipsum quia dolor sit amet'
+      key={2}
+      ariaSelected={false}
+    />
+  </Parent>
+)

--- a/src/layouts/dashboardLayout.js
+++ b/src/layouts/dashboardLayout.js
@@ -1,15 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import DashboardHeader from '../components/dashboardHeader/dashboardHeader'
+import GamesDropdown from '../components/gamesDropdown/gamesDropdown'
 import styles from './dashboardLayout.module.css'
 
-const DashboardLayout = ({ title, children }) => {
+const DashboardLayout = ({ title, includeGameSelect = false, children }) => {
   return(
     <div className={styles.root}>
       <div className={styles.container}>
         {title ?
-        <div className={styles.titleContainer}>
-          <h2 className={styles.title}>{title}</h2>
+        <div className={styles.headerContainer}>
+          <div className={styles.titleContainer}>
+            <h2 className={styles.title}>{title}</h2>
+            {includeGameSelect && <GamesDropdown />}
+          </div>
           <hr className={styles.hr} />
         </div> :
         null}
@@ -22,6 +26,7 @@ const DashboardLayout = ({ title, children }) => {
 
 DashboardLayout.propTypes = {
   title: PropTypes.string,
+  includeGameSelect: PropTypes.bool,
   children: PropTypes.node.isRequired
 }
 

--- a/src/layouts/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout.module.css
@@ -21,8 +21,13 @@
   max-width: 90%;
 }
 
-.titleContainer {
+.headerContainer {
   padding-top: 64px;
+}
+
+.titleContainer {
+  display: flex;
+  justify-content: space-between;
 }
 
 @media (min-width: 769px) {
@@ -30,7 +35,7 @@
     padding: 64px 0;
   }
 
-  .titleContainer {
+  .headerContainer {
     padding-top: 64px;
   }
 }

--- a/src/layouts/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout.module.css
@@ -5,6 +5,7 @@
 
 .title {
   font-family: 'Cinzel Decorative', sans-serif;
+  margin-bottom: 0.5rem;
 }
 
 .hr {
@@ -22,12 +23,19 @@
 }
 
 .headerContainer {
-  padding-top: 64px;
+  padding-top: 96px;
 }
 
 .titleContainer {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column-reverse;
+}
+
+@media (min-width: 601px) {
+  .titleContainer {
+    flex-direction: row;
+    justify-content: space-between;
+  }
 }
 
 @media (min-width: 769px) {

--- a/src/pages/shoppingListsPage/shoppingListsPage.js
+++ b/src/pages/shoppingListsPage/shoppingListsPage.js
@@ -49,7 +49,7 @@ const ShoppingListsPage = () => {
   ), [])
 
   return(
-    <DashboardLayout title='Your Shopping Lists'>
+    <DashboardLayout title='Your Shopping Lists' includeGameSelect>
       {listItemEditFormVisible && <Modal onClick={hideForm}><ShoppingListItemEditForm elementRef={formRef} {...listItemEditFormProps} /></Modal>}
       {flashVisible && <div className={styles.flash}><FlashMessage {...flashProps} /></div>}
       <div className={styles.createForm}><ShoppingListCreateForm disabled={shouldDisableForm} /></div>

--- a/src/sharedTestData.js
+++ b/src/sharedTestData.js
@@ -42,13 +42,13 @@ export const games = [
   {
     id: 572,
     user_id: 24,
-    name: 'My Game 2',
+    name: 'Neque porro quisquam est quis dolorem ipsum quia dolor sit amet',
     description: 'This is the second game'
   },
   {
     id: 231,
     user_id: 24,
-    name: 'My Game 3',
+    name: 'My Game 2',
     description: null
   }
 ]


### PR DESCRIPTION
## Context

[**Display shopping lists scoped to games**](https://trello.com/c/a3EZXsPQ/108-display-shopping-lists-scoped-to-games)

In the [last PR](https://github.com/danascheider/skyrim_inventory_management_frontend/pull/99), I scoped the shopping list page to games so that, by default, shopping lists from the first (most recently updated) game are shown and other games can be selected by setting the `game_id` query param.

We want the user to be able to select a game through the UI and view the shopping lists for that game. This PR introduces a `GamesDropdown` component, which sets the query param when an option is selected.

## Changes

* `GamesDropdown` and `GamesDropdownOption` components
* New test for selecting a game from the games dropdown to view shopping lists for a specific game
* Incorporate the games dropdown into the `DashboardLayout` with an `includeGameSelect` prop

## Considerations

It was really important to me that the dropdown list be styleable, so I decided to make a custom component instead of using a native `select` tag. However, I also wanted the component to be accessible, so I invested the time to implement the right ARIA attributes, focus, and keyboard behaviour. There is a detailed list of requirements for the dropdown in the linked card and more information on the ARIA combobox role is available [here](https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html).

One piece of functionality I decided to leave out for now was the filtering. The logic turned out to be a little complex and I couldn't decide quite what behaviour I wanted. The biggest challenge was that, when the input was populated with the default game name, the list was automatically filtered to contain only that game - obviously bad UX. I considered matching only shorter strings and showing the full list in the dropdown if the string matched one game's name exactly, but that wasn't quite right either. At the end I left it the way it is in this PR - if you press enter or blur the component after typing the exact name of a game (case insensitive), it'll set the game to the one you typed. But there is no filtering of options at this time.

## Manual Test Cases

Testing this PR should centre on the dropdown component - the correct game should be selected and the query string set when you click on any of the options or press Enter or Space while an option is focussed. When you click outside the component or when focus moves to an element outside the component, the dropdown should be hidden. If you de-focus the component after typing the full and complete name of one of the games (case doesn't matter), that game should be selected in the query string and its shopping lists should be visible.

## Screenshots and GIFs

### Dropdown Collapsed

#### 1201px

<img width="1203" alt="Screen Shot 2021-07-24 at 4 15 02 pm" src="https://user-images.githubusercontent.com/5115928/126859862-6c0febb0-d755-41b5-8f32-a32411e1c04c.png">

#### 1025px

<img width="1026" alt="Screen Shot 2021-07-24 at 4 15 16 pm" src="https://user-images.githubusercontent.com/5115928/126859869-39d22558-ebb7-4d6d-afbb-25839549b824.png">

#### 769px

<img width="770" alt="Screen Shot 2021-07-24 at 4 15 34 pm" src="https://user-images.githubusercontent.com/5115928/126859872-4c7d6cac-ffaa-4161-b7df-f7b94d7257e8.png">

#### 601px

<img width="601" alt="Screen Shot 2021-07-24 at 4 15 49 pm" src="https://user-images.githubusercontent.com/5115928/126859875-0995c116-1607-4567-82d0-84aee6972def.png">

#### 425px

<img width="426" alt="Screen Shot 2021-07-24 at 4 16 03 pm" src="https://user-images.githubusercontent.com/5115928/126859880-2c63e7d7-dc4f-408a-94de-f20a3a8da86a.png">

### Dropdown Expanded

#### 1201px

<img width="1202" alt="Screen Shot 2021-07-24 at 4 16 31 pm" src="https://user-images.githubusercontent.com/5115928/126859890-415d63b7-8047-4bac-9a17-fc6857b2922b.png">

#### 1025px

<img width="1025" alt="Screen Shot 2021-07-24 at 4 16 45 pm" src="https://user-images.githubusercontent.com/5115928/126859897-d06d8ac8-72e2-4805-a9c5-fe5023d4237e.png">

#### 769px

<img width="770" alt="Screen Shot 2021-07-24 at 4 17 00 pm" src="https://user-images.githubusercontent.com/5115928/126859909-f493768b-a04a-460e-b46c-2c70e8d997cc.png">

#### 601px

<img width="601" alt="Screen Shot 2021-07-24 at 4 17 15 pm" src="https://user-images.githubusercontent.com/5115928/126859913-e49da67c-2c80-415d-832e-a695d6ae3be1.png">

#### 425px

<img width="425" alt="Screen Shot 2021-07-24 at 4 17 31 pm" src="https://user-images.githubusercontent.com/5115928/126859916-3c9cdc18-9c02-4743-ba20-f84bc2b07dd6.png">
