### PR TITLE
Reenable shopping list creation

### DIFF
--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -2,8 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { BLUE } from '../../utils/colorSchemes'
-import { useAppContext, useGamesContext, useShoppingListsContext } from '../../hooks/contexts'
-import useQuery from '../../hooks/useQuery'
+import { useAppContext, useShoppingListsContext } from '../../hooks/contexts'
 import styles from './shoppingListCreateForm.module.css'
 
 const ShoppingListCreateForm = ({ disabled }) => {

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -2,15 +2,15 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { BLUE } from '../../utils/colorSchemes'
-import { useAppContext, useShoppingListsContext } from '../../hooks/contexts'
+import { useAppContext, useGamesContext, useShoppingListsContext } from '../../hooks/contexts'
+import useQuery from '../../hooks/useQuery'
 import styles from './shoppingListCreateForm.module.css'
 
 const ShoppingListCreateForm = ({ disabled }) => {
   const { setFlashVisible } = useAppContext()
 
-  const {
-    performShoppingListCreate
-  } = useShoppingListsContext()
+
+  const { performShoppingListCreate } = useShoppingListsContext()
 
   const [inputValue, setInputValue] = useState('')
 
@@ -30,12 +30,18 @@ const ShoppingListCreateForm = ({ disabled }) => {
     e.preventDefault()
     setFlashVisible(false)
     const title = e.target.elements.title.value
-    performShoppingListCreate(title, () => setInputValue(''))
+    const callbacks = {
+      onSuccess: () => setInputValue(''),
+      onNotFound: () => setFlashVisible(true),
+      onUnprocessableEntity: () => setFlashVisible(true),
+      onInternalServerError: () => setFlashVisible(true)
+    }
+    performShoppingListCreate(title, callbacks)
   }
 
   return(
     <div className={styles.root} style={colorVars}>
-      <form className={styles.form} onSubmit={createShoppingList}>
+      <form data-testid='shopping-list-create-form' onSubmit={createShoppingList}>
         <fieldset className={classNames(styles.fieldset, { [styles.fieldsetDisabled]: disabled })} disabled={disabled}>
           <input
             className={styles.input}

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -9,7 +9,6 @@ import styles from './shoppingListCreateForm.module.css'
 const ShoppingListCreateForm = ({ disabled }) => {
   const { setFlashVisible } = useAppContext()
 
-
   const { performShoppingListCreate } = useShoppingListsContext()
 
   const [inputValue, setInputValue] = useState('')

--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -236,11 +236,6 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
           // to set the shopping lists array to the lists returned.
           setShoppingLists(data)
 
-          setFlashProps({
-            type: 'success',
-            message: 'Success! Your list was created, along with your new aggregate shopping list.'
-          })
-
           onSuccess && onSuccess()
         } else if (data && typeof data === 'object' && !data.errors) {
           // It is the single shopping list that was created. This will happen if there
@@ -248,11 +243,6 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
           const newShoppingLists = shoppingLists
           newShoppingLists.splice(1, 0, data)
           setShoppingLists(newShoppingLists)
-
-          setFlashProps({
-            type: 'success',
-            message: 'Success! Your list was created.'
-          })
 
           onSuccess && onSuccess()
         } else if (data && typeof data === 'object' && data.errors ) {

--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -240,7 +240,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
         } else if (data && typeof data === 'object' && !data.errors) {
           // It is the single shopping list that was created. This will happen if there
           // is already an existing aggregate list.
-          const newShoppingLists = shoppingLists
+          const newShoppingLists = [...shoppingLists]
           newShoppingLists.splice(1, 0, data)
           setShoppingLists(newShoppingLists)
 

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.js
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.js
@@ -401,5 +401,241 @@ describe('ShoppingListsPage', () => {
         await waitFor(() => expect(screen.queryByText(/unexpected error/i)).toBeVisible())
       })
     })
+
+    describe('creating a shopping list', () => {
+      describe('happy path when the game has no other lists', () => {
+        const server = setupServer(
+          rest.get(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            const gameId = parseInt(req.params.gameId)
+            const lists = allShoppingLists.filter(list => list.game_id === gameId)
+
+            return res(
+              ctx.status(200),
+              ctx.json(lists)
+            )
+          }),
+          rest.post(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            const gameId = parseInt(req.params.gameId)
+            const title = req.body.shopping_list.title
+
+            const returnData = [
+              {
+                id: 1866,
+                game_id: gameId,
+                aggregate: true,
+                title: 'All Items',
+                list_items: []
+              },
+              {
+                id: 1867,
+                game_id: gameId,
+                aggregate: false,
+                title: title,
+                list_items: []
+              }
+            ]
+
+            return res(
+              ctx.status(201),
+              ctx.json(returnData)
+            )
+          })
+        )
+
+        beforeAll(() => server.listen())
+        beforeEach(() => server.resetHandlers())
+        afterAll(() => server.close())
+
+        it('creates the new shopping list and aggregate list for the active game', async () => {
+          component = renderComponentWithMockCookies(cookies, games[2].id)
+
+          const form = await screen.findByTestId('shopping-list-create-form')
+          const input = await screen.findByLabelText('Title')
+          
+          fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
+
+          act(() => {
+            fireEvent.submit(form)
+            return undefined;
+          })
+
+          await waitFor(() => expect(screen.queryByText('Proudspire Manor')).toBeVisible())
+          await waitFor(() => expect(screen.queryByText('All Items')).toBeVisible())
+        })
+      })
+
+      describe('happy path when the game has other lists', () => {
+        const server = setupServer(
+          rest.get(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            const gameId = parseInt(req.params.gameId)
+            const lists = allShoppingLists.filter(list => list.game_id === gameId)
+
+            return res(
+              ctx.status(200),
+              ctx.json(lists)
+            )
+          }),
+          rest.post(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            const gameId = parseInt(req.params.gameId)
+            const title = req.body.shopping_list.title
+
+            return res(
+              ctx.status(201),
+              ctx.json({
+                id: 1866,
+                game_id: gameId,
+                list_items: [],
+                title
+              })
+            )
+          })
+        )
+
+        beforeAll(() => server.listen())
+        beforeEach(() => server.resetHandlers())
+        afterAll(() => server.close())
+
+        it('creates the new shopping list for the active game', async () => {
+          component = renderComponentWithMockCookies(cookies, games[1].id)
+
+          const form = await screen.findByTestId('shopping-list-create-form')
+          const input = await screen.findByLabelText('Title')
+          
+          fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
+
+          act(() => {
+            fireEvent.submit(form)
+            return undefined;
+          })
+
+          await waitFor(() => expect(screen.queryByText('Proudspire Manor')).toBeVisible())
+        })
+      })
+
+      describe('when the game is not found', () => {
+        const server = setupServer(
+          rest.get(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            const gameId = parseInt(req.params.gameId)
+            const lists = allShoppingLists.filter(list => list.game_id === gameId)
+
+            return res(
+              ctx.status(200),
+              ctx.json(lists)
+            )
+          }),
+          rest.post(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            return res(
+              ctx.status(404),
+            )
+          })
+        )
+
+        beforeAll(() => server.listen())
+        beforeEach(() => server.resetHandlers())
+        afterAll(() => server.close())
+
+        it('displays a flash error message', async () => {
+          component = renderComponentWithMockCookies(cookies)
+
+          const form = await screen.findByTestId('shopping-list-create-form')
+          const input = await screen.findByLabelText('Title')
+          
+          fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
+
+          act(() => {
+            fireEvent.submit(form)
+            return undefined;
+          })
+
+          await waitFor(() => expect(screen.queryByText(/could not be found/i)).toBeVisible())
+        })
+      })
+
+      describe('when the attributes are invalid', () => {
+        const server = setupServer(
+          rest.get(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            const gameId = parseInt(req.params.gameId)
+            const lists = allShoppingLists.filter(list => list.game_id === gameId)
+
+            return res(
+              ctx.status(200),
+              ctx.json(lists)
+            )
+          }),
+          rest.post(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            return res(
+              ctx.status(422),
+              ctx.json({
+                errors: ['Title must be unique per game']
+              })
+            )
+          })
+        )
+
+        beforeAll(() => server.listen())
+        beforeEach(() => server.resetHandlers())
+        afterAll(() => server.close())
+
+        it("displays a flash error message and doesn't create the shopping list", async () => {
+          component = renderComponentWithMockCookies(cookies)
+
+          const form = await screen.findByTestId('shopping-list-create-form')
+          const input = await screen.findByLabelText('Title')
+          
+          fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
+
+          act(() => {
+            fireEvent.submit(form)
+            return undefined;
+          })
+
+          await waitFor(() => expect(screen.queryByText(/title must be unique per game/i)).toBeVisible())
+          await waitFor(() => expect(screen.queryByText(/proudspire manor/i)).not.toBeInTheDocument())
+        })
+      })
+
+      describe('when there is an unexpected error', () => {
+        const server = setupServer(
+          rest.get(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            const gameId = parseInt(req.params.gameId)
+            const lists = allShoppingLists.filter(list => list.game_id === gameId)
+
+            return res(
+              ctx.status(200),
+              ctx.json(lists)
+            )
+          }),
+          rest.post(`${backendBaseUri}/games/:gameId/shopping_lists`, (req, res, ctx) => {
+            return res(
+              ctx.status(500),
+              ctx.json({
+                errors: ['Something went horribly wrong']
+              })
+            )
+          })
+        )
+
+        beforeAll(() => server.listen())
+        beforeEach(() => server.resetHandlers())
+        afterAll(() => server.close())
+
+        it("displays a flash error message and doesn't create the shopping list", async () => {
+          component = renderComponentWithMockCookies(cookies)
+
+          const form = await screen.findByTestId('shopping-list-create-form')
+          const input = await screen.findByLabelText('Title')
+          
+          fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
+
+          act(() => {
+            fireEvent.submit(form)
+            return undefined;
+          })
+
+          await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())
+          await waitFor(() => expect(screen.queryByText(/proudspire manor/i)).not.toBeInTheDocument())
+        })
+      })
+    })
   })
 })

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.js
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.js
@@ -451,6 +451,7 @@ describe('ShoppingListsPage', () => {
 
           const form = await screen.findByTestId('shopping-list-create-form')
           const input = await screen.findByLabelText('Title')
+          const button = await screen.findByText('Create')
           
           fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
 
@@ -461,6 +462,9 @@ describe('ShoppingListsPage', () => {
 
           await waitFor(() => expect(screen.queryByText('Proudspire Manor')).toBeVisible())
           await waitFor(() => expect(screen.queryByText('All Items')).toBeVisible())
+          await waitFor(() => expect(input).not.toBeDisabled())
+          await waitFor(() => expect(button).not.toBeDisabled())
+          await waitFor(() => expect(input.value).toEqual(''))
         })
       })
 
@@ -500,6 +504,7 @@ describe('ShoppingListsPage', () => {
 
           const form = await screen.findByTestId('shopping-list-create-form')
           const input = await screen.findByLabelText('Title')
+          const button = await screen.findByText('Create')
           
           fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
 
@@ -509,6 +514,9 @@ describe('ShoppingListsPage', () => {
           })
 
           await waitFor(() => expect(screen.queryByText('Proudspire Manor')).toBeVisible())
+          await waitFor(() => expect(input).not.toBeDisabled())
+          await waitFor(() => expect(button).not.toBeDisabled())
+          await waitFor(() => expect(input.value).toEqual(''))
         })
       })
 
@@ -534,11 +542,12 @@ describe('ShoppingListsPage', () => {
         beforeEach(() => server.resetHandlers())
         afterAll(() => server.close())
 
-        it('displays a flash error message', async () => {
+        it("displays a flash error message but keeps the form enabled and doesn't clear it", async () => {
           component = renderComponentWithMockCookies(cookies)
 
           const form = await screen.findByTestId('shopping-list-create-form')
           const input = await screen.findByLabelText('Title')
+          const button = await screen.findByText('Create')
           
           fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
 
@@ -548,6 +557,9 @@ describe('ShoppingListsPage', () => {
           })
 
           await waitFor(() => expect(screen.queryByText(/could not be found/i)).toBeVisible())
+          await waitFor(() => expect(input).not.toBeDisabled())
+          await waitFor(() => expect(button).not.toBeDisabled())
+          await waitFor(() => expect(input.value).toEqual('Proudspire Manor'))
         })
       })
 
@@ -576,11 +588,12 @@ describe('ShoppingListsPage', () => {
         beforeEach(() => server.resetHandlers())
         afterAll(() => server.close())
 
-        it("displays a flash error message and doesn't create the shopping list", async () => {
+        it("displays a flash error message, doesn't create the shopping list or clear the form", async () => {
           component = renderComponentWithMockCookies(cookies)
 
           const form = await screen.findByTestId('shopping-list-create-form')
           const input = await screen.findByLabelText('Title')
+          const button = await screen.findByText('Create')
           
           fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
 
@@ -591,6 +604,9 @@ describe('ShoppingListsPage', () => {
 
           await waitFor(() => expect(screen.queryByText(/title must be unique per game/i)).toBeVisible())
           await waitFor(() => expect(screen.queryByText(/proudspire manor/i)).not.toBeInTheDocument())
+          await waitFor(() => expect(input).not.toBeDisabled())
+          await waitFor(() => expect(button).not.toBeDisabled())
+          await waitFor(() => expect(input.value).toEqual('Proudspire Manor'))
         })
       })
 
@@ -619,11 +635,12 @@ describe('ShoppingListsPage', () => {
         beforeEach(() => server.resetHandlers())
         afterAll(() => server.close())
 
-        it("displays a flash error message and doesn't create the shopping list", async () => {
+        it("displays a flash error message and doesn't create the shopping list or clear the form", async () => {
           component = renderComponentWithMockCookies(cookies)
 
           const form = await screen.findByTestId('shopping-list-create-form')
           const input = await screen.findByLabelText('Title')
+          const button = await screen.findByText('Create')
           
           fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
 
@@ -634,6 +651,9 @@ describe('ShoppingListsPage', () => {
 
           await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())
           await waitFor(() => expect(screen.queryByText(/proudspire manor/i)).not.toBeInTheDocument())
+          await waitFor(() => expect(input).not.toBeDisabled())
+          await waitFor(() => expect(button).not.toBeDisabled())
+          await waitFor(() => expect(input.value).toEqual('Proudspire Manor'))
         })
       })
 

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -151,9 +151,9 @@ export const fetchShoppingLists = (token, gameId) => {
   )
 }
 
-// POST /shopping_lists
-export const createShoppingList = (token, attrs) => {
-  const uri = `${backendBaseUri}/shopping_lists`
+// POST /games/:game_id/shopping_lists
+export const createShoppingList = (token, gameId, attrs) => {
+  const uri = `${backendBaseUri}/games/${gameId}/shopping_lists`
   const body = JSON.stringify({ shopping_list: attrs })
 
   return fetch(uri, {
@@ -163,6 +163,7 @@ export const createShoppingList = (token, attrs) => {
   })
   .then(resp => {
     if (resp.status === 401) throw new AuthorizationError()
+    if (resp.status === 404) throw new NotFoundError()
     return resp
   })
 }


### PR DESCRIPTION
## Context

[**Reenable shopping list creation**](https://trello.com/c/40pxKbov/109-reenable-shopping-list-creation)

Users are finally able to use the shopping lists page again, but so far the functionality to create a shopping list is still broken.

## Changes

* Update the `simApi`'s `createShoppingList` function to make correct API request to create a new list
* Correct `performShoppingListCreate` function in the `ShoppingListsProvider` to include the game ID when creating a list
* Use separate callbacks for each possible response and pass them in as an object instead of as separate positional arguments
* Update Storybook stories to make correct API calls and handle them correctly

## Considerations

Surprisingly little needed to be changed to make this functionality work. The game dropdown is working well and I was able to test it's functionality better now that I had the ability to create shopping lists.

## Manual Test Cases

There are 5 possible responses when creating a shopping list:

* 201 (when the shopping list, and possible an aggregate list, has been created)
* 401 (when the user's session has expired)
* 404 (when the game is not found or doesn't belong to the authenticated user)
* 422 (when the title the user has submitted is invalid or has already been used for this game)
* 500 (when something unexpected goes wrong)

Test out what happens in each of these scenarios. When testing success responses, make sure to test the case where the game has no existing lists (in which case you should see an All Items list created in addition to the list you created) and the case where the game has at least two existing lists (i.e., an aggregate list and a regular list). In this case, only the regular list will be created.