### PR TITLE
Ensure shopping list item deletion functionality works

### DIFF
--- a/docs/contexts/shopping-lists-context.md
+++ b/docs/contexts/shopping-lists-context.md
@@ -79,16 +79,23 @@ A function that updates the specified shopping list item, also encompassing erro
   * `quantity` (integer, greater than 0)
   * `notes` (string)
 * `showFlashOnSuccess`: whether a successful API call should result in a flash message being displayed (the flash message will always be displayed on failure)
-* `success`: an optional success callback that can be used for handling state within the component that calls the function
-* `error`: an optional error callback that can be used for cleaning up state within the component that calls the function
+* `callbacks`: an optional object with callbacks for each possible API response. Possible keys are:
+  * `onSuccess`: called when the API call returns a 200 or 204 response
+  * `onNotFound`: called when the shopping list being destroyed has already been previously destroyed
+  * `onUnauthorized`: called when the API returns a 401 response
+  * `onUnprocessableEntity`: called when the API returns a 422 response caused by validation errors
+  * `onInternalServerError`: called when there is a 500 error or other unexpected error (including 405 Method Not Allowed), or when there is an error in the response handler
 
 ### `performShoppingListItemDestroy`
 
 A function that destroys the specified shopping list item, also encompassing error handling logic. This also updates the aggregate list to reflect the change. The function takes three arguments:
 
 * `itemId`: the ID of the item to be destroyed
-* `success`: an optional success callback that can be used for handling state within the component that calls the function
-* `error`: an optional error callback that can be used for cleaning up state within the component that calls the function
+* `callbacks`: an optional object with callbacks for each possible API response. Possible keys are:
+  * `onSuccess`: called when the API call returns a 200 or 204 response
+  * `onNotFound`: called when the shopping list being destroyed has already been previously destroyed
+  * `onUnauthorized`: called when the API returns a 401 response
+  * `onInternalServerError`: called when there is a 500 error or other unexpected error (including 405 Method Not Allowed), or when there is an error in the response handler
 
 ### `listItemEditFormProps`
 

--- a/src/components/shoppingList/shoppingList.stories.js
+++ b/src/components/shoppingList/shoppingList.stories.js
@@ -185,6 +185,15 @@ Default.parameters = {
           ctx.status(404)
         )
       }
+    }),
+    // This request deletes the requested shopping list item, if it exists and
+    // belongs to the authenticated user. For the purposes of Storybook, we're
+    // going to make this just work each time without doing the aggregate list
+    // calculations, given that there is no aggregate list in this story.
+    rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(204)
+      )
     })
   ]
 }

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -176,7 +176,7 @@ const ShoppingListItem = ({
         <span className={classNames(styles.header, { [styles.headerEditable]: canEdit })}>
           {canEdit &&
             <span className={styles.editIcons} ref={iconsRef}>
-              <button className={styles.icon} ref={deleteRef} onClick={destroyItem}>
+              <button className={styles.icon} ref={deleteRef} onClick={destroyItem} data-testid='destroy-item'>
                 <FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon)} icon={faTimes} />
               </button>
               <button className={styles.icon} ref={editRef} onClick={showEditForm} data-testid='edit-item'>

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -133,7 +133,14 @@ const ShoppingListItem = ({
     const confirmed = window.confirm("Destroy shopping list item? Your aggregate list will be updated to reflect the change. This action cannot be undone.")
 
     if (confirmed) {
-      performShoppingListItemDestroy(itemId, () => { mountedRef.current = false })
+      const callbacks = {
+        onSuccess: () => mountedRef.current = false,
+        onUnauthorized: () => mountedRef.current = false,
+        onNotFound: () => setFlashVisible(true),
+        onInternalServerError: () => setFlashVisible(true)
+      }
+
+      performShoppingListItemDestroy(itemId, callbacks)
     } else {
       displayFlash('info', 'Your item was not deleted.')
     }

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
@@ -1,0 +1,506 @@
+import React from 'react'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { waitFor, screen, fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
+import { within } from '@testing-library/dom'
+import { cleanCookies } from 'universal-cookie/lib/utils'
+import { Cookies, CookiesProvider } from 'react-cookie'
+import { renderWithRouter } from '../../../../setupTests'
+import { backendBaseUri } from '../../../../utils/config'
+import { AppProvider } from '../../../../contexts/appContext'
+import { GamesProvider } from '../../../../contexts/gamesContext'
+import { ShoppingListsProvider } from '../../../../contexts/shoppingListsContext'
+import { profileData, games, allShoppingLists } from '../../../../sharedTestData'
+import {
+  findAggregateList,
+  findListByListItem,
+  removeOrAdjustItemOnItemDestroy
+} from '../../../../sharedTestUtilities'
+import ShoppingListsPage from './../../shoppingListsPage'
+
+describe('Destroying a shopping list item', () => {
+  let component
+
+  const renderComponentWithMockCookies = () => {
+    const route = `/dashboard/shopping_lists?game_id=${games[0].id}`
+
+    const shoppingLists = allShoppingLists.filter(list => list.game_id === games[0].id)
+
+    const cookies = new Cookies('_sim_google_session="xxxxxx"')
+    cookies.HAS_DOCUMENT_COOKIE = false
+
+    return renderWithRouter(
+      <CookiesProvider cookies={cookies}>
+        <AppProvider overrideValue={{ profileData }}>
+          <GamesProvider overrideValue={{ games, gameLoadingState: 'done' }} >
+            <ShoppingListsProvider overrideValue={{ shoppingLists, shoppingListLoadingState: 'done' }}>
+              <ShoppingListsPage />
+            </ShoppingListsProvider>
+          </GamesProvider>
+        </AppProvider>
+      </CookiesProvider>,
+      { route }
+    )
+  }
+
+  beforeEach(() => cleanCookies())
+  afterEach(() => component.unmount())
+
+  describe('when the user cancels when prompted', () => {
+    let confirm
+
+    beforeEach(() =>  confirm = jest.spyOn(window, 'confirm').mockImplementation(() => false))
+    afterEach(() => confirm.mockRestore())
+
+    it("doesn't remove the item from the regular list or the aggregate list", async () => {
+      component = renderComponentWithMockCookies()
+
+      // Start by finding the list the item is on. In this case, we'll be deleting the
+      // item 'Ingredients with "Frenzy" property' from the list 'Lakeview Manor'.
+      const listTitleEl = await screen.findByText('Lakeview Manor')
+      const listEl = listTitleEl.closest('.root')
+
+      // Expand the list to see the items
+      fireEvent.click(listTitleEl)
+
+      // Find the item on the list
+      const regItemDescEl = await within(listEl).findByText(/frenzy/i)
+      const regItemEl = regItemDescEl.closest('.root')
+
+      const destroyIcon = await within(regItemEl).findByTestId('destroy-item')
+
+      // Click on the destroy icon
+      fireEvent.click(destroyIcon)
+
+      // The user should have been prompted
+      await waitFor(() => expect(confirm).toHaveBeenCalled())
+
+      // The shopping list item should still be on the list
+      await waitFor(() => expect(regItemEl).toBeVisible())
+
+      // Find the aggregate list
+      const aggListTitle = await screen.findByText('All Items')
+      const aggListEl = aggListTitle.closest('.root')
+
+      // Expand the aggregate list to show the list items
+      fireEvent.click(aggListTitle)
+
+      // The list item should still be on the aggregate list too
+      await waitFor(() => expect(within(aggListEl).queryByText(/frenzy/i)).toBeVisible())
+
+      // There should be a flash info message
+      await waitFor(() => expect(screen.queryByText(/not deleted/i)).toBeVisible())
+    })
+  })
+
+  describe('when the aggregate list item is also removed', () => {
+    const server = setupServer(
+      rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(204)
+        )
+      })
+    )
+
+    let confirm
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+
+      // For this test, the user will confirm each time they are prompted
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
+    afterAll(() => server.close())
+
+    it('removes the item from the regular list and the aggregate list', async () => {
+      component = renderComponentWithMockCookies()
+
+      // Start by finding the list the item is on. In this case, we'll be deleting the
+      // item 'Ingredients with "Frenzy" property' from the list 'Lakeview Manor'.
+      const listTitleEl = await screen.findByText('Lakeview Manor')
+      const listEl = listTitleEl.closest('.root')
+
+      // Expand the list to see the items
+      fireEvent.click(listTitleEl)
+
+      // Find the item on the list
+      const regItemDescEl = await within(listEl).findByText(/frenzy/i)
+      const regItemEl = regItemDescEl.closest('.root')
+
+      const destroyIcon = await within(regItemEl).findByTestId('destroy-item')
+
+      // Click on the destroy icon
+      fireEvent.click(destroyIcon)
+
+      // The user should have been prompted
+      await waitFor(() => expect(confirm).toHaveBeenCalled())
+
+      // The item should be removed from the regular list
+      await waitForElementToBeRemoved(regItemEl)
+      expect(regItemEl).not.toBeInTheDocument()
+
+      // Find the aggregate list
+      const aggListTitle = await screen.findByText('All Items')
+      const aggListEl = aggListTitle.closest('.root')
+
+      // Expand the aggregate list to show the list items
+      fireEvent.click(aggListTitle)
+
+      // The list item should not be on the aggregate list either
+      await waitFor(() => expect(within(aggListEl).queryByText(/frenzy/i)).not.toBeInTheDocument())
+    })
+  })
+
+  describe('when the aggregate list item is not removed', () => {
+    const server = setupServer(
+      rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+        const itemId = parseInt(req.params.id)
+        const list = findListByListItem(allShoppingLists, itemId)
+        const item = list.list_items.find(i => i.id === itemId)
+        const aggList = findAggregateList(allShoppingLists, list.game_id)
+        const aggListItem = aggList.list_items.find(i => i.description.toLowerCase() === item.description.toLowerCase())
+
+        return res(
+          ctx.status(200),
+          ctx.json(removeOrAdjustItemOnItemDestroy(aggListItem, item))
+        )
+      })
+    )
+
+    let confirm
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+
+      // For this test, the user will confirm each time they are prompted
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
+    afterAll(() => server.close())
+
+    it('removes the item from the regular list but leaves it on the aggregate list', async () => {
+      component = renderComponentWithMockCookies()
+
+      // Start by finding the list the item is on. In this case, we'll be deleting the
+      // item 'Ingredients with "Frenzy" property' from the list 'Lakeview Manor'.
+      const listTitleEl = await screen.findByText('Lakeview Manor')
+      const listEl = listTitleEl.closest('.root')
+
+      // Expand the list to see the items
+      fireEvent.click(listTitleEl)
+
+      // Find the item on the list
+      const regItemDescEl = await within(listEl).findByText('Ebony sword')
+      const regItemEl = regItemDescEl.closest('.root')
+
+      const destroyIcon = await within(regItemEl).findByTestId('destroy-item')
+
+      // Click on the destroy icon
+      fireEvent.click(destroyIcon)
+
+      // The user should have been prompted
+      await waitFor(() => expect(confirm).toHaveBeenCalled())
+
+      // The item should be removed from the regular list
+      await waitForElementToBeRemoved(regItemEl)
+      expect(regItemEl).not.toBeInTheDocument()
+
+      // Find the aggregate list
+      const aggListTitle = await screen.findByText('All Items')
+      const aggListEl = aggListTitle.closest('.root')
+
+      // Expand the aggregate list to show the list items
+      fireEvent.click(aggListTitle)
+
+      // The list item should still be on the aggregate list
+      await waitFor(() => expect(within(aggListEl).queryByText('Ebony sword')).toBeVisible())
+    })
+  })
+
+  xdescribe('when the server returns a 401 error', () => {
+    const server = setupServer(
+      rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(401),
+          ctx.json({
+            errors: ['Google OAuth token validation failed']
+          })
+        )
+      })
+    )
+
+    beforeAll(() => server.listen())
+    beforeEach(() => server.resetHandlers())
+    afterAll(() => server.close())
+
+    it('redirects the user to the login page', async () => {
+      const { history } = component = renderComponentWithMockCookies()
+
+      // We're going to update an item on the 'Lakeview Manor' list
+      const listTitleEl = await screen.findByText('Lakeview Manor')
+      const listEl = listTitleEl.closest('.root')
+
+      fireEvent.click(listTitleEl)
+
+      // The list item we're going for is titled 'Ingredients with "Frenzy"
+      // property'. Its initial quantity is 4.
+      const itemDescEl = await within(listEl).findByText(/frenzy/i)
+      const itemEl = itemDescEl.closest('.root')
+      const editIcon = await within(itemEl).findByTestId('edit-item')
+
+      fireEvent.click(editIcon)
+
+      // It should display the list item edit form
+      const form = await screen.findByTestId('shopping-list-item-edit-form')
+      await waitFor(() => expect(form).toBeVisible())
+
+      // Now find the form fields and fill out the form. This item has no notes
+      // so we find the notes field by placeholder text instead.
+      const notesField = await within(form).findByPlaceholderText('This item has no notes')
+
+      // Fill out the form field. We'll change just the notes value for the
+      // sake of simplicity.
+      fireEvent.change(notesField, { target: { value: 'This item has notes now' } })
+
+      // Submit the  form
+      fireEvent.submit(form)
+
+      // The user should be redirected to the login page
+      await waitFor(() => expect(history.location.pathname).toEqual('/login'))
+    })
+  })
+
+  xdescribe('when the server returns a 404 error', () => {
+    const server = setupServer(
+      rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(404)
+        )
+      })
+    )
+
+    beforeAll(() => server.listen())
+    beforeEach(() => server.resetHandlers())
+    afterAll(() => server.close())
+
+    it("doesn't update the items and displays a flash error message", async () => {
+      component = renderComponentWithMockCookies()
+
+      // We're going to update an item on the 'Lakeview Manor' list
+      const listTitleEl = await screen.findByText('Lakeview Manor')
+      const listEl = listTitleEl.closest('.root')
+
+      fireEvent.click(listTitleEl)
+
+      // The list item we're going for is titled 'Ingredients with "Frenzy"
+      // property'. Its initial quantity is 4 and it has no notes.
+      const itemDescEl = await within(listEl).findByText(/frenzy/i)
+      const itemEl = itemDescEl.closest('.root')
+      const editIcon = await within(itemEl).findByTestId('edit-item')
+
+      fireEvent.click(editIcon)
+
+      // It should display the list item edit form
+      const form = await screen.findByTestId('shopping-list-item-edit-form')
+      await waitFor(() => expect(form).toBeVisible())
+
+      // Now find the form fields and fill out the form. This item has no notes
+      // so we find the notes field by placeholder text instead.
+      const notesField = await within(form).findByPlaceholderText('This item has no notes')
+
+      // Fill out the form field. We'll change just the notes value for the
+      // sake of simplicity.
+      fireEvent.change(notesField, { target: { value: 'This item has notes now' } })
+
+      // Submit the form
+      fireEvent.submit(form)
+
+      // The form should be hidden 
+      await waitForElementToBeRemoved(form)
+      expect(form).not.toBeInTheDocument()
+
+      // Now we need to find the item on the regular list and the
+      // aggregate list.
+      const aggListTitleEl = await screen.findByText('All Items')
+      const aggListEl = aggListTitleEl.closest('.root')
+
+      // Expand the list so the item is visible
+      fireEvent.click(aggListTitleEl)
+
+      // Then find the corresponding item
+      const aggListItemDescEl = await within(aggListEl).findByText(/frenzy/i)
+      const aggListItemEl = aggListItemDescEl.closest('.root')
+
+      // Expand the list item on each list to see the notes
+      fireEvent.click(aggListItemDescEl)
+      fireEvent.click(itemDescEl)
+
+      // Now we need to check that the aggregate list item and regular list
+      // item are updated.
+      await waitFor(() => expect(within(aggListItemEl).queryByText('This item has notes now')).not.toBeInTheDocument())
+      await waitFor(() => expect(within(listEl).queryByText('This item has notes now')).not.toBeInTheDocument())
+
+      // Finally, it should display the flash message.
+      await waitFor(() => expect(screen.queryByText(/couldn't find/i)).toBeVisible())
+    })
+  })
+
+  xdescribe('when the server returns a 422 error', () => {
+    const server = setupServer(
+      rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(422),
+          ctx.json({
+            errors: ['Quantity must be greater than zero']
+          })
+        )
+      })
+    )
+
+    beforeAll(() => server.listen())
+    beforeEach(() => server.resetHandlers())
+    afterAll(() => server.close())
+
+    it("doesn't update the items and displays a flash error message", async () => {
+      component = renderComponentWithMockCookies()
+
+      // We're going to update an item on the 'Lakeview Manor' list
+      const listTitleEl = await screen.findByText('Lakeview Manor')
+      const listEl = listTitleEl.closest('.root')
+
+      fireEvent.click(listTitleEl)
+
+      // The list item we're going for is titled 'Ingredients with "Frenzy"
+      // property'. Its initial quantity is 4 and it has no notes.
+      const itemDescEl = await within(listEl).findByText(/frenzy/i)
+      const itemEl = itemDescEl.closest('.root')
+      const editIcon = await within(itemEl).findByTestId('edit-item')
+
+      fireEvent.click(editIcon)
+
+      // It should display the list item edit form
+      const form = await screen.findByTestId('shopping-list-item-edit-form')
+      await waitFor(() => expect(form).toBeVisible())
+
+      // Now find the form fields and fill out the form.
+      const quantityField = await within(form).findByDisplayValue('4')
+
+      // In this case we'll set it to an invalid value
+      fireEvent.change(quantityField, { target: { value: '-6' } })
+
+      // Submit the form
+      fireEvent.submit(form)
+
+      // The form should be hidden 
+      await waitForElementToBeRemoved(form)
+      expect(form).not.toBeInTheDocument()
+
+      // Now we need to find the item on the regular list and the
+      // aggregate list.
+      const aggListTitleEl = await screen.findByText('All Items')
+      const aggListEl = aggListTitleEl.closest('.root')
+
+      // Expand the list so the item is visible
+      fireEvent.click(aggListTitleEl)
+
+      // Then find the corresponding item
+      const aggListItemDescEl = await within(aggListEl).findByText(/frenzy/i)
+      const aggListItemEl = aggListItemDescEl.closest('.root')
+
+      // Expand the list item on each list to see the notes
+      fireEvent.click(aggListItemDescEl)
+      fireEvent.click(itemDescEl)
+
+      // Now we need to check that the aggregate list item and regular list
+      // item are updated.
+      await waitFor(() => expect(within(aggListItemEl).queryByText('-6')).not.toBeInTheDocument())
+      await waitFor(() => expect(within(listEl).queryByText('-6')).not.toBeInTheDocument())
+
+      // Finally, it should display the flash message.
+      await waitFor(() => expect(screen.queryByText(/Quantity must be greater than zero/)).toBeVisible())
+    })
+  })
+
+  xdescribe('when the server returns a 500 error', () => {
+    const server = setupServer(
+      rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(500),
+          ctx.json({
+            errors: ['Something went horribly wrong']
+          })
+        )
+      })
+    )
+
+    beforeAll(() => server.listen())
+    beforeEach(() => server.resetHandlers())
+    afterAll(() => server.close())
+
+    it("doesn't update the items and displays a flash error message", async () => {
+      component = renderComponentWithMockCookies()
+
+      // We're going to update an item on the 'Lakeview Manor' list
+      const listTitleEl = await screen.findByText('Lakeview Manor')
+      const listEl = listTitleEl.closest('.root')
+
+      fireEvent.click(listTitleEl)
+
+      // The list item we're going for is titled 'Ingredients with "Frenzy"
+      // property'. Its initial quantity is 4 and it has no notes.
+      const itemDescEl = await within(listEl).findByText(/frenzy/i)
+      const itemEl = itemDescEl.closest('.root')
+      const editIcon = await within(itemEl).findByTestId('edit-item')
+
+      fireEvent.click(editIcon)
+
+      // It should display the list item edit form
+      const form = await screen.findByTestId('shopping-list-item-edit-form')
+      await waitFor(() => expect(form).toBeVisible())
+
+      // Now find the form fields and fill out the form.
+      const quantityField = await within(form).findByDisplayValue('4')
+
+      // In this case we'll set it to an invalid value
+      fireEvent.change(quantityField, { target: { value: '-6' } })
+
+      // Submit the form
+      fireEvent.submit(form)
+
+      // The form should be hidden 
+      await waitForElementToBeRemoved(form)
+      expect(form).not.toBeInTheDocument()
+
+      // Now we need to find the item on the regular list and the
+      // aggregate list.
+      const aggListTitleEl = await screen.findByText('All Items')
+      const aggListEl = aggListTitleEl.closest('.root')
+
+      // Expand the list so the item is visible
+      fireEvent.click(aggListTitleEl)
+
+      // Then find the corresponding item
+      const aggListItemDescEl = await within(aggListEl).findByText(/frenzy/i)
+      const aggListItemEl = aggListItemDescEl.closest('.root')
+
+      // Expand the list item on each list to see the notes
+      fireEvent.click(aggListItemDescEl)
+      fireEvent.click(itemDescEl)
+
+      // Now we need to check that the aggregate list item and regular list
+      // item are updated.
+      await waitFor(() => expect(within(aggListItemEl).queryByText('-6')).not.toBeInTheDocument())
+      await waitFor(() => expect(within(listEl).queryByText('-6')).not.toBeInTheDocument())
+
+      // Finally, it should display the flash message.
+      await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())
+    })
+  })
+})

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
@@ -270,17 +270,28 @@ describe('Destroying a shopping list item', () => {
     })
   })
 
-  xdescribe('when the server returns a 404 error', () => {
+  describe('when the server returns a 404 error', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
         return res(
-          ctx.status(404)
+          ctx.status(401),
+          ctx.json({
+            errors: ['Google OAuth token validation failed']
+          })
         )
       })
     )
 
+    let confirm
+
     beforeAll(() => server.listen())
-    beforeEach(() => server.resetHandlers())
+
+    beforeEach(() => {
+      server.resetHandlers()
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
     afterAll(() => server.close())
 
     it("doesn't update the items and displays a flash error message", async () => {
@@ -296,52 +307,22 @@ describe('Destroying a shopping list item', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const destroy = await within(itemEl).findByTestId('destroy-item')
 
-      fireEvent.click(editIcon)
+      fireEvent.click(destroy)
 
-      // It should display the list item edit form
-      const form = await screen.findByTestId('shopping-list-item-edit-form')
-      await waitFor(() => expect(form).toBeVisible())
+      // It should not remove the item
+      await waitFor(() => expect(listEl).toBeVisible())
 
-      // Now find the form fields and fill out the form. This item has no notes
-      // so we find the notes field by placeholder text instead.
-      const notesField = await within(form).findByPlaceholderText('This item has no notes')
+      // Find the aggregate list
+      const aggListTitle = await screen.findByText('All Items')
+      const aggListEl = aggListTitle.closest('.root')
 
-      // Fill out the form field. We'll change just the notes value for the
-      // sake of simplicity.
-      fireEvent.change(notesField, { target: { value: 'This item has notes now' } })
+      // Expand the aggregate list to show the list items
+      fireEvent.click(aggListTitle)
 
-      // Submit the form
-      fireEvent.submit(form)
-
-      // The form should be hidden 
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
-
-      // Now we need to find the item on the regular list and the
-      // aggregate list.
-      const aggListTitleEl = await screen.findByText('All Items')
-      const aggListEl = aggListTitleEl.closest('.root')
-
-      // Expand the list so the item is visible
-      fireEvent.click(aggListTitleEl)
-
-      // Then find the corresponding item
-      const aggListItemDescEl = await within(aggListEl).findByText(/frenzy/i)
-      const aggListItemEl = aggListItemDescEl.closest('.root')
-
-      // Expand the list item on each list to see the notes
-      fireEvent.click(aggListItemDescEl)
-      fireEvent.click(itemDescEl)
-
-      // Now we need to check that the aggregate list item and regular list
-      // item are updated.
-      await waitFor(() => expect(within(aggListItemEl).queryByText('This item has notes now')).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listEl).queryByText('This item has notes now')).not.toBeInTheDocument())
-
-      // Finally, it should display the flash message.
-      await waitFor(() => expect(screen.queryByText(/couldn't find/i)).toBeVisible())
+      // The list item should still be on the aggregate list too
+      await waitFor(() => expect(within(aggListEl).queryByText(/frenzy/i)).toBeVisible())
     })
   })
 

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
@@ -224,9 +224,9 @@ describe('Destroying a shopping list item', () => {
     })
   })
 
-  xdescribe('when the server returns a 401 error', () => {
+  describe('when the server returns a 401 error', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(401),
           ctx.json({
@@ -236,8 +236,16 @@ describe('Destroying a shopping list item', () => {
       })
     )
 
+    let confirm
+
     beforeAll(() => server.listen())
-    beforeEach(() => server.resetHandlers())
+
+    beforeEach(() => {
+      server.resetHandlers()
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
     afterAll(() => server.close())
 
     it('redirects the user to the login page', async () => {
@@ -250,27 +258,12 @@ describe('Destroying a shopping list item', () => {
       fireEvent.click(listTitleEl)
 
       // The list item we're going for is titled 'Ingredients with "Frenzy"
-      // property'. Its initial quantity is 4.
+      // property'
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const destroyIcon = await within(itemEl).findByTestId('destroy-item')
 
-      fireEvent.click(editIcon)
-
-      // It should display the list item edit form
-      const form = await screen.findByTestId('shopping-list-item-edit-form')
-      await waitFor(() => expect(form).toBeVisible())
-
-      // Now find the form fields and fill out the form. This item has no notes
-      // so we find the notes field by placeholder text instead.
-      const notesField = await within(form).findByPlaceholderText('This item has no notes')
-
-      // Fill out the form field. We'll change just the notes value for the
-      // sake of simplicity.
-      fireEvent.change(notesField, { target: { value: 'This item has notes now' } })
-
-      // Submit the  form
-      fireEvent.submit(form)
+      fireEvent.click(destroyIcon)
 
       // The user should be redirected to the login page
       await waitFor(() => expect(history.location.pathname).toEqual('/login'))

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
@@ -326,85 +326,9 @@ describe('Destroying a shopping list item', () => {
     })
   })
 
-  xdescribe('when the server returns a 422 error', () => {
+  describe('when the server returns a 500 error', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
-        return res(
-          ctx.status(422),
-          ctx.json({
-            errors: ['Quantity must be greater than zero']
-          })
-        )
-      })
-    )
-
-    beforeAll(() => server.listen())
-    beforeEach(() => server.resetHandlers())
-    afterAll(() => server.close())
-
-    it("doesn't update the items and displays a flash error message", async () => {
-      component = renderComponentWithMockCookies()
-
-      // We're going to update an item on the 'Lakeview Manor' list
-      const listTitleEl = await screen.findByText('Lakeview Manor')
-      const listEl = listTitleEl.closest('.root')
-
-      fireEvent.click(listTitleEl)
-
-      // The list item we're going for is titled 'Ingredients with "Frenzy"
-      // property'. Its initial quantity is 4 and it has no notes.
-      const itemDescEl = await within(listEl).findByText(/frenzy/i)
-      const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
-
-      fireEvent.click(editIcon)
-
-      // It should display the list item edit form
-      const form = await screen.findByTestId('shopping-list-item-edit-form')
-      await waitFor(() => expect(form).toBeVisible())
-
-      // Now find the form fields and fill out the form.
-      const quantityField = await within(form).findByDisplayValue('4')
-
-      // In this case we'll set it to an invalid value
-      fireEvent.change(quantityField, { target: { value: '-6' } })
-
-      // Submit the form
-      fireEvent.submit(form)
-
-      // The form should be hidden 
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
-
-      // Now we need to find the item on the regular list and the
-      // aggregate list.
-      const aggListTitleEl = await screen.findByText('All Items')
-      const aggListEl = aggListTitleEl.closest('.root')
-
-      // Expand the list so the item is visible
-      fireEvent.click(aggListTitleEl)
-
-      // Then find the corresponding item
-      const aggListItemDescEl = await within(aggListEl).findByText(/frenzy/i)
-      const aggListItemEl = aggListItemDescEl.closest('.root')
-
-      // Expand the list item on each list to see the notes
-      fireEvent.click(aggListItemDescEl)
-      fireEvent.click(itemDescEl)
-
-      // Now we need to check that the aggregate list item and regular list
-      // item are updated.
-      await waitFor(() => expect(within(aggListItemEl).queryByText('-6')).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listEl).queryByText('-6')).not.toBeInTheDocument())
-
-      // Finally, it should display the flash message.
-      await waitFor(() => expect(screen.queryByText(/Quantity must be greater than zero/)).toBeVisible())
-    })
-  })
-
-  xdescribe('when the server returns a 500 error', () => {
-    const server = setupServer(
-      rest.patch(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(500),
           ctx.json({
@@ -414,8 +338,16 @@ describe('Destroying a shopping list item', () => {
       })
     )
 
+    let confirm
+
     beforeAll(() => server.listen())
-    beforeEach(() => server.resetHandlers())
+
+    beforeEach(() => {
+      server.resetHandlers()
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
     afterAll(() => server.close())
 
     it("doesn't update the items and displays a flash error message", async () => {
@@ -431,49 +363,24 @@ describe('Destroying a shopping list item', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const destroy = await within(itemEl).findByTestId('destroy-item')
 
-      fireEvent.click(editIcon)
+      fireEvent.click(destroy)
 
-      // It should display the list item edit form
-      const form = await screen.findByTestId('shopping-list-item-edit-form')
-      await waitFor(() => expect(form).toBeVisible())
+      // It should not remove the item
+      await waitFor(() => expect(listEl).toBeVisible())
 
-      // Now find the form fields and fill out the form.
-      const quantityField = await within(form).findByDisplayValue('4')
+      // Find the aggregate list
+      const aggListTitle = await screen.findByText('All Items')
+      const aggListEl = aggListTitle.closest('.root')
 
-      // In this case we'll set it to an invalid value
-      fireEvent.change(quantityField, { target: { value: '-6' } })
+      // Expand the aggregate list to show the list items
+      fireEvent.click(aggListTitle)
 
-      // Submit the form
-      fireEvent.submit(form)
+      // The list item should still be on the aggregate list too
+      await waitFor(() => expect(within(aggListEl).queryByText(/frenzy/i)).toBeVisible())
 
-      // The form should be hidden 
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
-
-      // Now we need to find the item on the regular list and the
-      // aggregate list.
-      const aggListTitleEl = await screen.findByText('All Items')
-      const aggListEl = aggListTitleEl.closest('.root')
-
-      // Expand the list so the item is visible
-      fireEvent.click(aggListTitleEl)
-
-      // Then find the corresponding item
-      const aggListItemDescEl = await within(aggListEl).findByText(/frenzy/i)
-      const aggListItemEl = aggListItemDescEl.closest('.root')
-
-      // Expand the list item on each list to see the notes
-      fireEvent.click(aggListItemDescEl)
-      fireEvent.click(itemDescEl)
-
-      // Now we need to check that the aggregate list item and regular list
-      // item are updated.
-      await waitFor(() => expect(within(aggListItemEl).queryByText('-6')).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listEl).queryByText('-6')).not.toBeInTheDocument())
-
-      // Finally, it should display the flash message.
+      // There should be a flash error message
       await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())
     })
   })

--- a/src/pages/shoppingListsPage/shoppingListsPage.stories.js
+++ b/src/pages/shoppingListsPage/shoppingListsPage.stories.js
@@ -317,60 +317,60 @@ HappyPath.parameters = {
           ctx.status(404)
         )
       }
+    }),
+    // This request deletes the requested shopping list item, if it exists and
+    // belongs to the authenticated user. For the purposes of Storybook, we're
+    // assuming that the user is authenticated and the `allShoppingLists` array
+    // represents all their shopping lists for all their games.
+    rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+      // Find the item and the list it is on.
+      const itemId = parseInt(req.params.id)
+      const regList = findListByListItem(allShoppingLists, itemId)
+
+      if (regList) {
+        // If the list exists (i.e., if the item has been found on one of the
+        // lists for that game), find the item itself.
+        const item = regList.list_items.find(listItem => listItem.id === itemId)
+
+        // Find the item on the aggregate list.
+        const aggregateList = findAggregateList(allShoppingLists, regList.game_id)
+
+        // This will blow up if `aggregateList` is `null` but because there are
+        // aggregate lists hard-coded into the test data it would actually kind
+        // of be good to know if that wasn't making it into here properly.
+        let aggregateListItem = aggregateList.list_items.find(listItem => (
+          listItem.description.toLowerCase() === item.description.toLowerCase()
+        ))
+
+        aggregateListItem = removeOrAdjustItemOnItemDestroy(aggregateListItem, item)
+
+        if (aggregateListItem) {
+          // If the aggregate list item has a higher quantity than the item destroyed,
+          // meaning that there is another matching item on another shopping list for
+          // the same game, then the adjusted aggregate list item will be returned from
+          // the API.
+          return res(
+            ctx.status(200),
+            ctx.json(aggregateListItem)
+          )
+        } else {
+          // If the aggregate list item has a quantity equal to that of the item
+          // destroyed (meaning there are no other matching items on any of that
+          // game's othere lists), then it will be removed from the databasee and
+          // the API will return a 204 No Content response.
+          return res(
+            ctx.status(204)
+          )
+        }
+      } else {
+        // If the object `regList` is null, it means that the list item wasn't
+        // found in any list's array of list items. The list item doesn't exist
+        // or doesn't belong to the authenticated user.
+        return res(
+          ctx.status(204)
+        )
+      }
     })
-    // // This request deletes the requested shopping list item, if it exists and
-    // // belongs to the authenticated user. For the purposes of Storybook, we're
-    // // assuming that the user is authenticated and the `allShoppingLists` array
-    // // represents all their shopping lists for all their games.
-    // rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
-    //   // Find the item and the list it is on.
-    //   const itemId = parseInt(req.params.id)
-    //   const regList = findListByListItem(allShoppingLists, itemId)
-
-    //   if (regList) {
-    //     // If the list exists (i.e., if the item has been found on one of the
-    //     // lists for that game), find the item itself.
-    //     const item = regList.list_items.find(listItem => listItem.id === itemId)
-
-    //     // Find the item on the aggregate list.
-    //     const aggregateList = findAggregateList(allShoppingLists, regList.id)
-
-    //     // This will blow up if `aggregateList` is `null` but because there are
-    //     // aggregate lists hard-coded into the test data it would actually kind
-    //     // of be good to know if that wasn't making it into here properly.
-    //     const aggregateListItem = aggregateList.list_items.find(listItem => (
-    //       listItem.description.toLowerCase() === item.description.toLowerCase()
-    //     ))
-
-    //     removeOrAdjustItemOnItemDestroy(aggregateListItem, item)
-
-    //     if (aggregateListItem) {
-    //       // If the aggregate list item has a higher quantity than the item destroyed,
-    //       // meaning that there is another matching item on another shopping list for
-    //       // the same game, then the adjusted aggregate list item will be returned from
-    //       // the API.
-    //       return res(
-    //         ctx.status(200),
-    //         ctx.json(aggregateListItem)
-    //       )
-    //     } else {
-    //       // If the aggregate list item has a quantity equal to that of the item
-    //       // destroyed (meaning there are no other matching items on any of that
-    //       // game's othere lists), then it will be removed from the databasee and
-    //       // the API will return a 204 No Content response.
-    //       return res(
-    //         ctx.status(204)
-    //       )
-    //     }
-    //   } else {
-    //     // If the object `regList` is null, it means that the list item wasn't
-    //     // found in any list's array of list items. The list item doesn't exist
-    //     // or doesn't belong to the authenticated user.
-    //     return res(
-    //       ctx.status(204)
-    //     )
-    //   }
-    // })
   ]
 }
 
@@ -561,7 +561,18 @@ ListOrItemsNotFound.parameters = {
       return res(
         ctx.status(404)
       )
+    }),
+    // This illustrates what would happen if a user tried to destroy a shopping list item
+    // that had been previously deleted on another device or browser. Since the item has
+    // already been deleted, this would ordinarily result in just removing the item from
+    // the page, but because of aggregate list behaviour, it's going to actually result
+    // in an error being displayed advising the user to refresh their browser.
+    rest.delete(`${backendBaseUri}/shopping_list_items/:id`, (req, res, ctx) => {
+      return res(
+        ctx.status(404)
+      )
     })
+
   ]
 }
 

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -256,7 +256,7 @@ export const updateShoppingListItem = (token, itemId, attrs) => {
 }
 
 // DELETE /shopping_list_items/:id
-export const destroyShoppingListItem = (token, itemId, attrs) => {
+export const destroyShoppingListItem = (token, itemId) => {
   const uri = `${backendBaseUri}/shopping_list_items/${itemId}`
 
   return(


### PR DESCRIPTION
## Context

* [**Test shopping list item functionality**](https://trello.com/c/Lu9zIVD3/112-test-shopping-list-item-functionality)
* [**Add test cases for deleting a shopping list item**](https://trello.com/c/BwiVftj2/87-add-test-cases-for-deleting-a-shopping-list-item)

As we're fixing up shopping list functionality to work with games, we need to make sure we can still delete shopping list items from their lists and see the expected behaviour. There were no Jest tests around this functionality so it was necessary to add some.

## Changes

* Jest tests for happy path and error cases when removing a shopping list item
* Storybook fixes
* Docs update
* Small refactor of callbacks to `performShoppingListDestroy`

## Considerations

I again removed handling for 405 errors since the UI doesn't provide a way for users to do anything that would cause those errors. They should be treated as unexpected errors.

## Manual Test Cases

Just delete some items from lists and make sure everything works.
