### PR TITLE
Fix bug in games dropdown

### DIFF
--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -14,11 +14,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons'
 import { BLUE } from '../../utils/colorSchemes'
 import { useGamesContext } from '../../hooks/contexts'
+import useQuery from '../../hooks/useQuery'
 import GamesDropdownOption from '../gamesDropdownOption/gamesDropdownOption'
 import styles from './gamesDropdown.module.css'
 
 const GamesDropdown = () => {
   const history = useHistory()
+  const queryString = useQuery()
 
   const { games } = useGamesContext()
 
@@ -59,10 +61,15 @@ const GamesDropdown = () => {
 
   useEffect(() => {
     if (!activeGame && games.length) {
-      setActiveGame(games[0])
-      setInputValue(games[0].name)
+      const gameId = parseInt(queryString.get('game_id'))
+      const game = gameId ? games.find(game => game.id === gameId) : games[0]
+
+      if (game) {
+        setActiveGame(game)
+        setInputValue(game.name)
+      }
     }
-  }, [activeGame, games])
+  }, [activeGame, games, queryString])
 
   useEffect(() => {
     const collapseDropdownAndResetValue = e => {


### PR DESCRIPTION
## Context

[**Fix bug in games dropdown**](https://trello.com/c/YUpsHsyd/124-fix-bug-in-games-dropdown)

When collapsed, the `GamesDropdown` component should show the active game. However, there was a bug where, if the user refreshed the page, the dropdown would reset to show its default game (i.e., the first one on the list) and ignore the active game from the query string.

## Changes

* Ensure that query string is the source of truth for the active game in the `GamesDropdown`

## Considerations

It was a pretty straightforward bug to fix.

## Manual Test Cases

Go to the shopping lists page. Select a game other than the first one from the games dropdown. See that the lists for that game are displayed. Refresh the page. See that that game's name is the active one in the `GamesDropdown`.
