### PR TITLE
Enable games dropdown when active game not found

### DIFF
--- a/src/components/gamesDropdown/gamesDropdown.js
+++ b/src/components/gamesDropdown/gamesDropdown.js
@@ -69,6 +69,8 @@ const GamesDropdown = () => {
 
       if (game) {
         selectGame(game)
+      } else {
+        selectGame(games[0])
       }
     } else if (games.length && !activeGame) {
       selectGame(games[0])


### PR DESCRIPTION
## Context

[**Enable games dropdown when active game not found**](https://trello.com/c/wUSiMIzg/127-enable-games-dropdown-when-active-game-not-found)

The core work of this card had already been done - the games dropdown is already enabled when the active game is not found. However, it would be better to have an existing game automatically selected in the dropdown in this scenario.

## Changes

* Select first game as active game in the games dropdown if user enters a nonexistent game ID in the query string
