### PR TITLE
QA bug fix

### DIFF
--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -28,11 +28,17 @@ const ShoppingListCreateForm = ({ disabled }) => {
     e.preventDefault()
     setFlashVisible(false)
     const title = e.target.elements.title.value
+
+    const showFlashAndClearInput = () => {
+      setInputValue('')
+      setFlashVisible(true)
+    }
+
     const callbacks = {
       onSuccess: () => setInputValue(''),
-      onNotFound: () => setFlashVisible(true),
+      onNotFound: showFlashAndClearInput,
       onUnprocessableEntity: () => setFlashVisible(true),
-      onInternalServerError: () => setFlashVisible(true)
+      onInternalServerError: showFlashAndClearInput
     }
     performShoppingListCreate(title, callbacks)
   }

--- a/src/pages/shoppingListsPage/__tests__/createList.test.js
+++ b/src/pages/shoppingListsPage/__tests__/createList.test.js
@@ -179,7 +179,7 @@ describe('Creating a shopping list', () => {
     beforeEach(() => server.resetHandlers())
     afterAll(() => server.close())
 
-    it("displays a flash error message but keeps the form enabled and doesn't clear it", async () => {
+    it("displays a flash error message and clears the form but doesn't disable it", async () => {
       component = renderComponentWithMockCookies()
 
       // Find the shopping list create form
@@ -196,7 +196,7 @@ describe('Creating a shopping list', () => {
       // The input form should not be cleared or disabled
       await waitFor(() => expect(input).not.toBeDisabled())
       await waitFor(() => expect(button).not.toBeDisabled())
-      await waitFor(() => expect(input.value).toEqual('Proudspire Manor'))
+      await waitFor(() => expect(input.value).toEqual(''))
     })
   })
 
@@ -274,7 +274,7 @@ describe('Creating a shopping list', () => {
     beforeEach(() => server.resetHandlers())
     afterAll(() => server.close())
 
-    it("displays a flash error message and doesn't create the shopping list or clear the form", async () => {
+    it("displays a flash error message and clears the form but doesn't create the shopping list", async () => {
       component = renderComponentWithMockCookies()
 
       // Find the shopping list create form
@@ -294,7 +294,7 @@ describe('Creating a shopping list', () => {
       // The form should not be cleared or disabled
       await waitFor(() => expect(input).not.toBeDisabled())
       await waitFor(() => expect(button).not.toBeDisabled())
-      await waitFor(() => expect(input.value).toEqual('Proudspire Manor'))
+      await waitFor(() => expect(input.value).toEqual(''))
     })
   })
 


### PR DESCRIPTION
## Context

[**Game model**](https://trello.com/c/dm3cE8ip/30-game-model)

We've now finished QA in development for the game feature. This PR includes fixes for the one issue we found.

## Changes

* Clear the shopping list create form when an error from the server is anything but 422
* Update tests

## Considerations

This wasn't actually a bug, but rather intended behaviour that I decided should be different after poking around with it. For that reason, tests have been updated too.

## Manual Test Cases

### 404 Error

1. Add the following line to the `ShoppingListsController::CreateService` in your development environment (add it as the first line of the `#perform` method):
  ```ruby
  raise ActiveRecord::RecordNotFound.new
  ```
2. Go to the shopping lists page on the front end
3. Fill out the creation form and submit it
4. See that the form has been cleared
5. See that there is a flash error telling you to refresh the page

### 422 Error

1. Go to the shopping lists page on the front end
2. Fill out the creation form with a duplicate title and submit it
3. See that the form has not been cleared
4. See that there is a flash error message with the validation error

### 500 Error

1. Add the following line to the `ShoppingListsController::CreateService` in your development environment (add it as the first line of the `#perform` method):
  ```ruby
  raise StandardError.new
  ```
2. Go to the shopping lists page on the front end
3. Fill out the creation form and submit it
4. See that the form has been cleared
5. See that there is a flash error telling you something unexpected happened