### PR TITLE
Refactor simApi module to return response status and JSON

### DIFF
--- a/src/components/game/game.js
+++ b/src/components/game/game.js
@@ -64,7 +64,7 @@ const Game = ({ gameId, name, description }) => {
     if (confirmed) {
       const callbacks = {
         onSuccess: displayFlashAndUnmount,
-        onInternalServerError: () => setFlashVisible(true)
+        onInternalServerError: () => mountedRef.current && setFlashVisible(true)
       }
 
       performGameDestroy(gameId, callbacks)
@@ -79,7 +79,7 @@ const Game = ({ gameId, name, description }) => {
   }
 
   useEffect(() => (
-    mountedRef.current = false
+    () => mountedRef.current = false
   ), [])
 
   return(

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
@@ -45,22 +45,17 @@ const ShoppingListItemCreateForm = ({ listId }) => {
     const notes = e.target.elements.notes.value
     const attrs = { description, quantity, notes }
 
+    const resetToggleAndDisplayFlash = () => {
+      formRef.current.reset()
+      toggleForm()
+      setFlashVisible(true)
+    }
+
     const callbacks = {
-      onSuccess: () => {
-        formRef.current.reset()
-        toggleForm()
-      },
-      onNotFound: () => {
-        formRef.current.reset()
-        toggleForm()
-        setFlashVisible(true)
-      },
+      onSuccess: resetToggleAndDisplayFlash,
+      onNotFound: resetToggleAndDisplayFlash,
       onUnprocessableEntity: () => setFlashVisible(true),
-      onInternalServerError: () => {
-        formRef.current.reset()
-        toggleForm()
-        setFlashVisible(true)
-      }
+      onInternalServerError: resetToggleAndDisplayFlash
     }
 
     performShoppingListItemCreate(listId, attrs, callbacks)

--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -92,12 +92,11 @@ const AppProvider = ({ children, overrideValue = {} }) => {
   const fetchProfileData = () => {
     if (shouldFetchProfileData()) {
       fetchUserProfile(cookies[sessionCookieName])
-        .then(response => response.json())
-        .then(data => {
-          if (data.errors) {
-            throw new Error('Internal Server Error: ', data.errors[0])
+        .then(({ status, json }) => {
+          if (status !== 200) {
+            throw new Error('Internal Server Error: ', json.errors[0])
           } else if (mountedRef.current === true) {
-            setProfileData(data)
+            setProfileData(json)
             if (!overrideValue.profileLoadState) setProfileLoadState(DONE)
           }
         })

--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -93,11 +93,13 @@ const AppProvider = ({ children, overrideValue = {} }) => {
     if (shouldFetchProfileData()) {
       fetchUserProfile(cookies[sessionCookieName])
         .then(({ status, json }) => {
-          if (status !== 200) {
-            throw new Error('Internal Server Error: ', json.errors[0])
-          } else if (mountedRef.current === true) {
+          if (!mountedRef.current) return
+
+          if (status === 200) {
             setProfileData(json)
             if (!overrideValue.profileLoadState) setProfileLoadState(DONE)
+          } else {
+            throw new Error('Internal Server Error: ', json.errors[0])
           }
         })
         .catch(error => {

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -55,7 +55,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
               !overrideValue.gameLoadingState && setGameLoadingState(DONE)
             }
           } else {
-            const message = json && json.errors ? `Error ${status} when fetching games: ${json.errors}` : 'No game data returned from SIM'
+            const message = json.errors ? `Error ${status} when fetching games: ${json.errors}` : 'No game data returned from SIM'
             throw new Error(message)
           }
         })

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -107,7 +107,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           onUnprocessableEntity && onUnprocessableEntity()
         } else {
           // Something unexpected happened and we don't know what.
-          throw new Error(json.errors ? `Error ${status} when creating game: ${json.errors}` : `Error ${status} when creating game`)
+          throw new Error(json.errors ? `Error ${status} when creating game: ${json.errors}` : `Unknown error ${status} when creating game`)
         }
       })
       .catch(err => {

--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -337,7 +337,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
       .then(({ status, json }) => {
         if (!mountedRef.current) return
 
-        if (status === 200) {
+        if (status === 200 || status === 201) {
           const [aggregateListItem, regularListItem] = json
 
           // Have to create an actual new object or the state change won't cause useEffect
@@ -354,6 +354,18 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
           newLists[regularListPosition] = newRegularList
 
           setShoppingLists(newLists)
+
+          if (status === 201) {
+            setFlashProps({
+              type: 'success',
+              message: 'Success! Your shopping list item has been created.'
+            })
+          } else {
+            setFlashProps({
+              type: 'success',
+              message: 'Success! Your new shopping list item has been combined with another item with the same description.'
+            })
+          }
 
           onSuccess && onSuccess()
         } else if (status === 422) {

--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -109,13 +109,14 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
   const fetchLists = useCallback(() => {
     if (token && !shoppingListsOverridden.current) {
       fetchShoppingLists(token, activeGameId)
-        .then(resp => resp.json())
-        .then(data => {
-          if (mountedRef.current && data && !data.errors) {
-            setShoppingLists(data)
-            !overrideValue.shoppingListLoadingState && setShoppingListLoadingState(DONE)
-          } else if (mountedRef.current) {
-            const message = data && data.errors ? `Internal ServerError: ${data.errors[0]}` : 'No shopping list data returned from the SIM API'
+        .then(({ status, json }) => {
+          if (status === 200) {
+            if (mountedRef.current) {
+              setShoppingLists(json)
+              !overrideValue.shoppingListLoadingState && setShoppingListLoadingState(DONE)
+            }
+          } else {
+            const message = json.errors ? `Error ${status} while fetching shopping lists: ${json.errors}` : `Unknown error ${status} while fetching shopping lists`
             throw new Error(message)
           }
         })

--- a/src/pages/shoppingListsPage/__tests__/destroyList.test.js
+++ b/src/pages/shoppingListsPage/__tests__/destroyList.test.js
@@ -100,12 +100,12 @@ describe('Destroying a shopping list', () => {
 
       // Both the list and aggregate list should be removed
       await waitFor(() => expect(listEl).not.toBeInTheDocument())
-      expect(screen.queryByText(/all items/i)).not.toBeInTheDocument()
+      expect(screen.queryByText('All Items')).not.toBeInTheDocument()
 
       // There should be a flash message indicating that the list and its aggregate list
       // have both been destroyed
       await waitFor(() => expect(screen.queryByText(/shopping list has been deleted/i)).toBeVisible())
-      await waitFor(() => expect(screen.queryByText(/aggregate list has been deleted/i)).toBeVisible())
+      await waitFor(() => expect(screen.queryByText(/"All Items" list has been deleted/i)).toBeVisible())
     })
   })
 

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItemHappyPath.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItemHappyPath.test.js
@@ -67,7 +67,7 @@ describe('Creating a shopping list item - happy path', () => {
         ]
 
         return res(
-          ctx.status(200),
+          ctx.status(201),
           ctx.json(json)
         )
       })
@@ -124,15 +124,19 @@ describe('Creating a shopping list item - happy path', () => {
 
       fireEvent.click(allItemsTitle)
 
-      const item = await within(allItemsEl).findByText('Dwarven metal ingots')
-      const itemEl = item.closest('.root')
+      const itemTitleOnAggList = await within(allItemsEl).findByText('Dwarven metal ingots')
+      const itemElOnAggList = itemTitleOnAggList.closest('.root')
 
-      expect(item).toBeVisible()
-      
-      fireEvent.click(item)
+      expect(itemElOnAggList).toBeVisible()
 
-      await waitFor(() => expect(within(itemEl).queryByText('10')).toBeVisible())
-      await waitFor(() => expect(within(itemEl).queryByText('To make bolts with')).toBeVisible())
+      // Expand the item to show its attributes
+      fireEvent.click(itemTitleOnAggList)
+
+      await waitFor(() => expect(within(itemElOnAggList).queryByText('10')).toBeVisible())
+      await waitFor(() => expect(within(itemElOnAggList).queryByText('To make bolts with')).toBeVisible())
+
+      // There should be a flash message visible
+      await waitFor(() => expect(screen.queryByText(/has been created/i)).toBeVisible())
     })
   })
 
@@ -162,7 +166,7 @@ describe('Creating a shopping list item - happy path', () => {
         ]
 
         return res(
-          ctx.status(200),
+          ctx.status(201),
           ctx.json(json)
         )
       })
@@ -315,15 +319,19 @@ describe('Creating a shopping list item - happy path', () => {
 
       fireEvent.click(allItemsTitle)
 
-      const item = await within(allItemsEl).findByText('Ebony sword')
-      const itemEl = item.closest('.root')
+      const itemTitleOnAggList = await within(allItemsEl).findByText('Ebony sword')
+      const itemElOnAggList = itemTitleOnAggList.closest('.root')
 
-      expect(itemEl).toBeVisible()
-      
-      fireEvent.click(item)
+      expect(itemElOnAggList).toBeVisible()
 
-      await waitFor(() => expect(within(itemEl).queryByText('4')).toBeVisible())
-      await waitFor(() => expect(within(itemEl).queryByText('notes 1 -- notes 2 -- notes 3')).toBeVisible())
+      // Expand the item to see its attributes
+      fireEvent.click(itemTitleOnAggList)
+
+      await waitFor(() => expect(within(itemElOnAggList).queryByText('4')).toBeVisible())
+      await waitFor(() => expect(within(itemElOnAggList).queryByText('notes 1 -- notes 2 -- notes 3')).toBeVisible())
+
+      // There should be a flash message indicating the item was combined with another item
+      await waitFor(() => expect(screen.queryByText(/combined with another item/i)).toBeVisible())
     })
   })
 })

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -188,8 +188,7 @@ export const updateShoppingList = (token, listId, attrs) => {
       // JSON to handle the error
       if (resp.status === 401) throw new AuthorizationError()
       if (resp.status === 404) throw new NotFoundError('Shopping list not found. Try refreshing the page to resolve this issue.')
-      if (resp.status === 405) throw new MethodNotAllowedError('Aggregate lists are managed automatically and cannot be updated manually.')
-      return resp
+      return resp.json().then(json => ({ status: resp.status, json }))
     })
   )
 }

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -55,7 +55,7 @@ export const fetchUserProfile = token => {
     fetch(uri, { headers: authHeader(token) })
       .then(resp => {
         if (resp.status === 401) throw new AuthorizationError()
-        return resp
+        return resp.json().then(json => ({ status: resp.status, json }))
       })
   )
 }

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -249,6 +249,7 @@ export const updateShoppingListItem = (token, itemId, attrs) => {
     .then(resp => {
       if (resp.status === 401) throw new AuthorizationError()
       if (resp.status === 404) throw new NotFoundError("You tried to update a list item that doesn't exist. Try refreshing to fix this issue.")
+      if (resp.status === 405) throw new MethodNotAllowedError('Items on aggregate shopping lists cannot be updated through the API')
       return resp.json().then(json => ({ status: resp.status, json }))
     })
   )

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -231,7 +231,7 @@ export const createShoppingListItem = (token, listId, attrs) => {
     .then(resp => {
       if (resp.status === 401) throw new AuthorizationError()
       if (resp.status === 404) throw new NotFoundError("You tried to create an item on a list that doesn't exist. Try refreshing to resolve this issue.")
-      return resp
+      return resp.json().then(json => ({ status: resp.status, json }))
     })
   )
 }

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -249,8 +249,7 @@ export const updateShoppingListItem = (token, itemId, attrs) => {
     .then(resp => {
       if (resp.status === 401) throw new AuthorizationError()
       if (resp.status === 404) throw new NotFoundError("You tried to update a list item that doesn't exist. Try refreshing to fix this issue.")
-      if (resp.status === 405) throw new MethodNotAllowedError()
-      return resp
+      return resp.json().then(json => ({ status: resp.status, json }))
     })
   )
 }

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -164,7 +164,7 @@ export const createShoppingList = (token, gameId, attrs) => {
   .then(resp => {
     if (resp.status === 401) throw new AuthorizationError()
     if (resp.status === 404) throw new NotFoundError()
-    return resp
+    return resp.json().then(json => ({ status: resp.status, json }))
   })
 }
 

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -74,7 +74,7 @@ export const fetchGames = token => {
     fetch(uri, { headers: authHeader(token) })
       .then(resp => {
         if (resp.status === 401) throw new AuthorizationError()
-        return resp
+        return resp.json().then(json => ({ status: resp.status, json }))
       })
   )
 }
@@ -108,7 +108,7 @@ export const updateGame = (token, gameId, attrs) => {
   .then(resp => {
     if (resp.status === 401) throw new AuthorizationError()
     if (resp.status === 404) throw new NotFoundError()
-    return resp
+    return resp.json().then(json => ({ status: resp.status, json }))
   })
 }
 

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -267,7 +267,8 @@ export const destroyShoppingListItem = (token, itemId) => {
       if (resp.status === 401) throw new AuthorizationError()
       if (resp.status === 404) throw new NotFoundError("You tried to delete a list item that doesn't exist. Try refreshing to fix this issue.")
       if (resp.status === 405) throw new MethodNotAllowedError()
-      return resp
+      if (resp.status === 204) return { status: resp.status, json: null }
+      return resp.json().then(json => ({ status: resp.status, json }))
     })
   )
 }

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -91,7 +91,7 @@ export const createGame = (token, attrs) => {
   })
   .then(resp => {
     if (resp.status === 401) throw new AuthorizationError()
-    return resp
+    return resp.json().then(json => ({ status: resp.status, json }))
   })
 }
 

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -146,7 +146,7 @@ export const fetchShoppingLists = (token, gameId) => {
       .then(resp => {
         if (resp.status === 401) throw new AuthorizationError()
         if (resp.status === 404) throw new NotFoundError()
-        return resp
+        return resp.json().then(json => ({ status: resp.status, json }))
       })
   )
 }

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -206,7 +206,8 @@ export const destroyShoppingList = (token, listId) => {
       if (resp.status === 401) throw new AuthorizationError()
       if (resp.status === 404) throw new NotFoundError('Shopping list not found. Try refreshing the page to resolve this issue.')
       if (resp.status === 405) throw new MethodNotAllowedError('Aggregate lists are managed automatically and cannot be deleted manually.')
-      return resp
+      if (resp.status === 204) return { status: resp.status, json: null }
+      return resp.json().then(json => ({ status: resp.status, json }))
     })
   )
 }


### PR DESCRIPTION
## Context

[**Refactor simApi module to return response status and JSON**](https://trello.com/c/GkqpK2L4/122-refactor-simapi-module-to-return-response-status-and-json)

Because of the way handlers are chained to `fetch`, we weren't able to have access to a response status and JSON in the same handlers. That meant in many cases making conclusions about the status based on the shape of the body. It would be better to have access to both the response and the status in the same handler.

## Changes

* Return response status and JSON from `simApi` functions
* Refactor code that calls `simApi` functions to work with the new return value

## Considerations

I didn't refactor the `destroyGame` function because it won't return JSON anyway.

## Manual Test Cases

This should not affect application behaviour.