### PR TITLE
Add HTML form validations to prevent some 422 errors

### DIFF
--- a/src/components/gameCreateForm/gameCreateForm.js
+++ b/src/components/gameCreateForm/gameCreateForm.js
@@ -72,6 +72,7 @@ const GameCreateForm = ({ disabled }) => {
                   name='name'
                   placeholder='Name'
                   aria-label='Name'
+                  required
                 />
               </fieldset>
               <fieldset className={classNames(styles.fieldset, { [styles.fieldsetDisabled]: disabled })} disabled={disabled}>

--- a/src/components/gameCreateForm/gameCreateForm.js
+++ b/src/components/gameCreateForm/gameCreateForm.js
@@ -72,7 +72,7 @@ const GameCreateForm = ({ disabled }) => {
                   name='name'
                   placeholder='Name'
                   aria-label='Name'
-                  pattern="\s*[A-Za-z0-9 \-',]*\s*"
+                  pattern="^\s*[A-Za-z0-9 \-',]*\s*$"
                   title="Name can contain only alphanumeric characters, spaces, commas, hyphens, and apostrophes"
                   required
                 />

--- a/src/components/gameCreateForm/gameCreateForm.js
+++ b/src/components/gameCreateForm/gameCreateForm.js
@@ -72,6 +72,8 @@ const GameCreateForm = ({ disabled }) => {
                   name='name'
                   placeholder='Name'
                   aria-label='Name'
+                  pattern="\s*[A-Za-z0-9 \-',]*\s*"
+                  title="Name can contain only alphanumeric characters, spaces, commas, hyphens, and apostrophes"
                   required
                 />
               </fieldset>

--- a/src/components/modalGameForm/modalGameForm.js
+++ b/src/components/modalGameForm/modalGameForm.js
@@ -14,7 +14,8 @@ const formFields = [
     placeholder: 'Name',
     inputMode: 'text',
     required: true,
-    pattern: "\\s*[A-Za-z0-9 \\-',]*\\s*"
+    pattern: "\\s*[A-Za-z0-9 \\-',]*\\s*",
+    title: 'Name can only contain alphanumeric characters, spaces, commas, hyphens, and apostrophes'
   },
   {
     name: 'description',

--- a/src/components/modalGameForm/modalGameForm.js
+++ b/src/components/modalGameForm/modalGameForm.js
@@ -14,7 +14,7 @@ const formFields = [
     placeholder: 'Name',
     inputMode: 'text',
     required: true,
-    pattern: "\\s*[A-Za-z0-9 \\-',]*\\s*",
+    pattern: "^\\s*[A-Za-z0-9 \\-',]*\\s*$",
     title: 'Name can only contain alphanumeric characters, spaces, commas, hyphens, and apostrophes'
   },
   {

--- a/src/components/modalGameForm/modalGameForm.js
+++ b/src/components/modalGameForm/modalGameForm.js
@@ -12,7 +12,9 @@ const formFields = [
     label: 'Name',
     type: 'text',
     placeholder: 'Name',
-    inputMode: 'text'
+    inputMode: 'text',
+    required: true,
+    pattern: "\\s*[A-Za-z0-9 \\-',]*\\s*"
   },
   {
     name: 'description',

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -55,7 +55,7 @@ const ShoppingListCreateForm = ({ disabled }) => {
             aria-label='Title'
             value={inputValue}
             onChange={updateValue}
-            pattern="\s*[A-Za-z0-9 \-',]*\s*"
+            pattern="^\s*[A-Za-z0-9 \-',]*\s*$"
             title='Title can only contain alphanumeric characters, spaces, commas, hyphens, and apostrophes'
             required
           />

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -55,6 +55,9 @@ const ShoppingListCreateForm = ({ disabled }) => {
             aria-label='Title'
             value={inputValue}
             onChange={updateValue}
+            pattern="\s*[A-Za-z0-9 \-',]*\s*"
+            title='Title can only contain alphanumeric characters, spaces, commas, hyphens, and apostrophes'
+            required
           />
           <button className={classNames(styles.button, { [styles.buttonDisabled]: disabled })} type='submit'>Create</button>
         </fieldset>

--- a/src/components/shoppingListEditForm/shoppingListEditForm.js
+++ b/src/components/shoppingListEditForm/shoppingListEditForm.js
@@ -66,7 +66,7 @@ const ShoppingListEditForm = ({ formRef, maxTotalWidth, className, title, onSubm
         ref={inputRef}
         style={{width: inputWidth}}
         value={inputValue}
-        pattern="\s*[A-Za-z0-9 \-',]*\s*"
+        pattern="^\s*[A-Za-z0-9 \-',]*\s*$"
         title='Title can only contain alphanumeric characters, spaces, hyphens, commas, and apostrophes'
         required
       />

--- a/src/components/shoppingListEditForm/shoppingListEditForm.js
+++ b/src/components/shoppingListEditForm/shoppingListEditForm.js
@@ -66,6 +66,9 @@ const ShoppingListEditForm = ({ formRef, maxTotalWidth, className, title, onSubm
         ref={inputRef}
         style={{width: inputWidth}}
         value={inputValue}
+        pattern="\s*[A-Za-z0-9 \-',]*\s*"
+        title='Title can only contain alphanumeric characters, spaces, hyphens, commas, and apostrophes'
+        required
       />
       <button className={styles.submit} ref={buttonRef} name='submit' type='submit'>
         <FontAwesomeIcon className={styles.fa} icon={faCheckSquare} />

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.js
@@ -73,17 +73,17 @@ const ShoppingListItemCreateForm = ({ listId }) => {
           <div className={styles.collapsible} ref={setCollapsibleElement}>
             <form className={styles.form} ref={formRef} onSubmit={createShoppingListItem}>
               <fieldset className={styles.fieldset}>
-                <label className={styles.label} htmlFor='description'>Description</label>
-                <input className={styles.input} type='text' name='description' placeholder='Description' />
+                <label className={styles.label}>Description</label>
+                <input className={styles.input} type='text' name='description' placeholder='Description' required />
               </fieldset>
 
               <fieldset className={styles.fieldset}>
-                <label className={styles.label} htmlFor='quantity'>Quantity</label>
-                <input className={styles.input} type='number' inputMode='numeric' name='quantity' defaultValue={1} />
+                <label className={styles.label}>Quantity</label>
+                <input className={styles.input} type='number' inputMode='numeric' min={1} name='quantity' defaultValue={1} required />
               </fieldset>
 
               <fieldset className={styles.fieldset}>
-                <label className={styles.label} htmlFor='notes'>Notes</label>
+                <label className={styles.label}>Notes</label>
                 <input className={styles.input} type='text' name='notes' placeholder='Notes' />
               </fieldset>
 

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.js
@@ -10,7 +10,9 @@ const formFields = [
     label: 'Quantity',
     type: 'number',
     placeholder: 'Quantity',
-    inputMode: 'numeric'
+    inputMode: 'numeric',
+    min: 1,
+    required: true
   },
   {
     name: 'notes',

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -119,7 +119,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
         } else {
           if (process.env.NODE_ENV === 'development') console.error('Error creating game: ', err)
 
-          setFlashProps({
+          mountedRef.current && setFlashProps({
             type: 'error',
             message: "Something unexpected happened while creating your game. Unfortunately, we don't know more than that yet. We're working on it!"
           })

--- a/src/pages/gamesPage/__tests__/createGame.test.js
+++ b/src/pages/gamesPage/__tests__/createGame.test.js
@@ -77,61 +77,71 @@ describe('Creating a game on the games page', () => {
     })
   })
 
-  describe('form validation errors', () => {
-    it("doesn't submit without a name", async () => {
-      component = renderComponentWithMockCookies()
+  // I'm commenting out these tests. They are passing, but CORS errors in
+  // the console are telling me that something isn't quite right with them.
+  // The form is submitting despite the validation errors due to a bug in
+  // JSDOM that has unfortunately been around for quite some time without
+  // being fixed or anyone finding a workaround.
+  // https://github.com/jsdom/jsdom/issues/2898
 
-      // Click the link that triggers the create form to become visible
-      const toggleLink = await screen.findByText('Create Game...')
-      fireEvent.click(toggleLink)
+  // I'm leaving the dead code here because I don't want the tests to be
+  // forgotten about.
 
-      // Fill out and submit the creation form, leaving the name blank
-      const nameInput = await screen.findByLabelText('Name')
-      const descInput = await screen.findByLabelText('Description')
-      const form = await screen.findByTestId('game-create-form')
+  // describe('form validation errors', () => {
+  //   it("doesn't submit without a name", async () => {
+  //     component = renderComponentWithMockCookies()
 
-      fireEvent.change(nameInput, { target: { value: '' } })
-      fireEvent.change(descInput, { target: { value: 'New game description' } })
-      fireEvent.submit(form)
+  //     // Click the link that triggers the create form to become visible
+  //     const toggleLink = await screen.findByText('Create Game...')
+  //     fireEvent.click(toggleLink)
 
-      // The form should not be reset or hidden
-      await waitFor(() => expect(form).toBeVisible())
-      await waitFor(() => expect(screen.queryByDisplayValue('New game description')).toBeVisible())
+  //     // Fill out and submit the creation form, leaving the name blank
+  //     const nameInput = await screen.findByLabelText('Name')
+  //     const descInput = await screen.findByLabelText('Description')
+  //     const form = await screen.findByTestId('game-create-form')
 
-      // The flash message should not be visible. A validation error should not show up
-      // and neither should the CORS error that will be returned if the form submits
-      // during this test since no API request handler is defined.
-      await waitFor(() => expect(screen.queryByText(/error\(s\)/)).not.toBeInTheDocument())
-      await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
-    })
+  //     fireEvent.change(nameInput, { target: { value: '' } })
+  //     fireEvent.change(descInput, { target: { value: 'New game description' } })
+  //     fireEvent.submit(form)
 
-    it("doesn't submit with an invalid name", async () => {
-      component = renderComponentWithMockCookies()
+  //     // The form should not be reset or hidden
+  //     await waitFor(() => expect(form).toBeVisible())
+  //     await waitFor(() => expect(screen.queryByDisplayValue('New game description')).toBeVisible())
 
-      // Click the link that triggers the create form to become visible
-      const toggleLink = await screen.findByText('Create Game...')
-      fireEvent.click(toggleLink)
+  //     // The flash message should not be visible. A validation error should not show up
+  //     // and neither should the CORS error that will be returned if the form submits
+  //     // during this test since no API request handler is defined.
+  //     await waitFor(() => expect(screen.queryByText(/error\(s\)/)).not.toBeInTheDocument())
+  //     await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
+  //   })
 
-      // Fill out and submit the creation form, leaving the name blank
-      const nameInput = await screen.findByLabelText('Name')
-      const descInput = await screen.findByLabelText('Description')
-      const form = await screen.findByTestId('game-create-form')
+  //   it("doesn't submit with an invalid name", async () => {
+  //     component = renderComponentWithMockCookies()
 
-      fireEvent.change(nameInput, { target: { value: '@$75*&@$' } })
-      fireEvent.change(descInput, { target: { value: 'New game description' } })
-      fireEvent.submit(form)
+  //     // Click the link that triggers the create form to become visible
+  //     const toggleLink = await screen.findByText('Create Game...')
+  //     fireEvent.click(toggleLink)
 
-      // The form should not be reset or hidden
-      await waitFor(() => expect(form).toBeVisible())
-      await waitFor(() => expect(screen.queryByDisplayValue('New game description')).toBeVisible())
+  //     // Fill out and submit the creation form, leaving the name blank
+  //     const nameInput = await screen.findByLabelText('Name')
+  //     const descInput = await screen.findByLabelText('Description')
+  //     const form = await screen.findByTestId('game-create-form')
 
-      // The flash message should not be visible. A validation error should not show up
-      // and neither should the CORS error that will be returned if the form submits
-      // during this test since no API request handler is defined.
-      await waitFor(() => expect(screen.queryByText(/error\(s\)/)).not.toBeInTheDocument())
-      await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
-    })
-  })
+  //     fireEvent.change(nameInput, { target: { value: '@$75*&@$' } })
+  //     fireEvent.change(descInput, { target: { value: 'New game description' } })
+  //     fireEvent.submit(form)
+
+  //     // The form should not be reset or hidden
+  //     await waitFor(() => expect(form).toBeVisible())
+  //     await waitFor(() => expect(screen.queryByDisplayValue('New game description')).toBeVisible())
+
+  //     // The flash message should not be visible. A validation error should not show up
+  //     // and neither should the CORS error that will be returned if the form submits
+  //     // during this test since no API request handler is defined.
+  //     await waitFor(() => expect(screen.queryByText(/error\(s\)/)).not.toBeInTheDocument())
+  //     await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
+  //   })
+  // })
 
   describe('with invalid attributes', () => {
     const server = setupServer(

--- a/src/pages/gamesPage/__tests__/createGame.test.js
+++ b/src/pages/gamesPage/__tests__/createGame.test.js
@@ -77,6 +77,32 @@ describe('Creating a game on the games page', () => {
     })
   })
 
+  describe('form validation errors', () => {
+    it("doesn't submit without a name", async () => {
+      component = renderComponentWithMockCookies()
+
+      // Click the link that triggers the create form to become visible
+      const toggleLink = await screen.findByText('Create Game...')
+      fireEvent.click(toggleLink)
+
+      // Fill out and submit the creation form, leaving the name blank
+      const nameInput = await screen.findByLabelText('Name')
+      const descInput = await screen.findByLabelText('Description')
+      const form = await screen.findByTestId('game-create-form')
+
+      fireEvent.change(nameInput, { target: { value: '' } })
+      fireEvent.change(descInput, { target: { value: 'New game description' } })
+      fireEvent.submit(form)
+
+      // The form should not be reset or hidden
+      await waitFor(() => expect(form).toBeVisible())
+      await waitFor(() => expect(screen.queryByDisplayValue('New game description')).toBeVisible())
+
+      // The flash message should not be visible
+      await waitFor(() => expect(screen.queryByText(/error\(s\)/)).not.toBeInTheDocument())
+    })
+  })
+
   describe('with invalid attributes', () => {
     const server = setupServer(
       rest.post(`${backendBaseUri}/games`, (req, res, ctx) => {

--- a/src/pages/gamesPage/__tests__/createGame.test.js
+++ b/src/pages/gamesPage/__tests__/createGame.test.js
@@ -98,8 +98,38 @@ describe('Creating a game on the games page', () => {
       await waitFor(() => expect(form).toBeVisible())
       await waitFor(() => expect(screen.queryByDisplayValue('New game description')).toBeVisible())
 
-      // The flash message should not be visible
+      // The flash message should not be visible. A validation error should not show up
+      // and neither should the CORS error that will be returned if the form submits
+      // during this test since no API request handler is defined.
       await waitFor(() => expect(screen.queryByText(/error\(s\)/)).not.toBeInTheDocument())
+      await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
+    })
+
+    it("doesn't submit with an invalid name", async () => {
+      component = renderComponentWithMockCookies()
+
+      // Click the link that triggers the create form to become visible
+      const toggleLink = await screen.findByText('Create Game...')
+      fireEvent.click(toggleLink)
+
+      // Fill out and submit the creation form, leaving the name blank
+      const nameInput = await screen.findByLabelText('Name')
+      const descInput = await screen.findByLabelText('Description')
+      const form = await screen.findByTestId('game-create-form')
+
+      fireEvent.change(nameInput, { target: { value: '@$75*&@$' } })
+      fireEvent.change(descInput, { target: { value: 'New game description' } })
+      fireEvent.submit(form)
+
+      // The form should not be reset or hidden
+      await waitFor(() => expect(form).toBeVisible())
+      await waitFor(() => expect(screen.queryByDisplayValue('New game description')).toBeVisible())
+
+      // The flash message should not be visible. A validation error should not show up
+      // and neither should the CORS error that will be returned if the form submits
+      // during this test since no API request handler is defined.
+      await waitFor(() => expect(screen.queryByText(/error\(s\)/)).not.toBeInTheDocument())
+      await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
     })
   })
 

--- a/src/pages/gamesPage/__tests__/editGame.test.js
+++ b/src/pages/gamesPage/__tests__/editGame.test.js
@@ -156,6 +156,94 @@ describe('Editing a game on the games page', () => {
     })
   })
 
+  // I'm commenting out these tests because they will never pass due to yet
+  // another bug in JSDOM. The functionality needs to be tested but I'm not
+  // sure what else to try and nobody has apparently been able to find a
+  // workaround for the bug. https://github.com/jsdom/jsdom/issues/2898
+
+  // I'm leaving the dead code here because I don't want the tests to be
+  // forgotten about.
+
+  // describe('form validations', () => {
+  //   const { name, description } = games[0]
+
+  //   it("doesn't submit without a name", async () => {
+  //     component = renderComponentWithMockCookies()
+
+  //     const gameTitle = await screen.findByText(name)
+  //     const gameEl = gameTitle.closest('.root')
+
+  //     // The icon you click to display the form
+  //     const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+
+  //     // Display the edit form
+  //     fireEvent.click(editIcon)
+
+  //     const form = await screen.findByTestId('game-form')
+  //     const nameInput = await within(form).findByDisplayValue(name)
+  //     const descInput = await within(form).findByDisplayValue(description)
+
+  //     // Fill out the inputs
+  //     fireEvent.change(nameInput, { target: { value: '' } })
+  //     fireEvent.change(descInput, { target: { value: 'New description' } })
+
+  //     // Submit the edit form
+  //     fireEvent.submit(form)
+
+  //     // Form should be visible and not cleared
+  //     await waitFor(() => expect(form).toBeVisible())
+  //     await waitFor(() => expect(screen.queryByDisplayValue('New description')).toBeVisible())
+
+  //     // The game should still appear in the list under its old name
+  //     await waitFor(() => expect(screen.queryByText(name)).toBeVisible())
+
+  //     // No flash message should be displayed, either for the validation error
+  //     // or for the CORS error that will be raised if this test makes an API
+  //     // request (since it isn't expected to)
+  //     await waitFor(() => expect(screen.queryByText(/success/i)).not.toBeInTheDocument())
+  //     await waitFor(() => expect(screen.queryByText(/error\(s\)/i)).not.toBeInTheDocument())
+  //     await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
+  //   })
+
+  //   it("doesn't submit with an invalid name", async () => {
+  //     component = renderComponentWithMockCookies()
+
+  //     const gameTitle = await screen.findByText(name)
+  //     const gameEl = gameTitle.closest('.root')
+
+  //     // The icon you click to display the form
+  //     const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+
+  //     // Display the edit form
+  //     fireEvent.click(editIcon)
+
+  //     const form = await screen.findByTestId('game-form')
+  //     const nameInput = await within(form).findByDisplayValue(name)
+  //     const descInput = await within(form).findByDisplayValue(description)
+
+  //     // Fill out the inputs
+  //     fireEvent.change(nameInput, { target: { value: '@$75*&@$' } })
+  //     fireEvent.change(descInput, { target: { value: 'New description' } })
+
+  //     // Submit the edit form
+  //     fireEvent.submit(form)
+
+  //     // Form should be visible and not cleared
+  //     await waitFor(() => expect(form).toBeVisible())
+  //     await waitFor(() => expect(screen.queryByDisplayValue('New description')).toBeVisible())
+
+  //     // The game should still appear in the list under its old name
+  //     await waitFor(() => expect(screen.queryByText(name)).toBeVisible())
+
+  //     // No flash message should be displayed, either for the validation error
+  //     // or for the CORS error that will be raised if this test makes an API
+  //     // request (since it isn't expected to)
+  //     await waitFor(() => expect(screen.queryByText(/success/i)).not.toBeInTheDocument())
+  //     await waitFor(() => expect(screen.queryByText(/error\(s\)/i)).not.toBeInTheDocument())
+  //     await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
+  //   })
+  // })
+
   describe("when the game doesn't exist", () => {
     const server = setupServer(
       rest.patch(`${backendBaseUri}/games/:id`, (req, res, ctx) => {


### PR DESCRIPTION
## Context

[**Add front-end form validations**](https://trello.com/c/prvOfEaT/133-add-front-end-form-validations)

We're looking at [redesigning the flash message component](https://trello.com/c/mi1ybGp3/116-redesign-flash-messages), and one of the goals we've come to is that we want users to see that component as infrequently as possible. One great way to minimise how much users see the flash message is to add form validations to prevent them from submitting forms with invalid attributes.

I've limited the scope of this card to adding what HTML form validations were possible. Additional validations, such as uniqueness validations, can be handled through JavaScript, but I have created a [new card](https://trello.com/c/mWZ8vWcv/134-beef-up-javascript-form-validations) for this work since it is likely to be more involved. Although I don't want to prioritise the validations above the next epic, I'll probably in fact do that card concurrently with the [Inventory List epic](https://trello.com/c/D6opBEo2/130-inventory-lists) since that epic will involve adding new forms that will also need validations. The new forms will give us an opportunity to trial the [Formik form library](https://formik.org/), which looks promising but turns up rather frequently in issue reports against the testing libraries we're using, suggesting they may not play nice.

## Changes

* Add form validations to all existing forms for validated models
* Add (commented-out) tests to remind us to test this functionality either when JSDOM fixes their bug or we change validation approach

## Considerations

Infuriatingly, I had to give up on automated testing for the validation functionality because of a [bug in JSDOM](https://github.com/jsdom/jsdom/issues/2898) that causes forms to be submitted regardless of validation errors. The tests that I wrote before discovering this bug are still in the code, commented out, because I don't want to forget to test this functionality when it becomes feasible to do so or when we change validation approaches such that JSDOM works (maybe it'll work with JS validations better than HTML ones, in other words). I didn't add more tests after discovering the JSDOM bug.

Useful validation error messages in Safari will, unfortunately, have to wait until the JS validations have been implemented since Safari doesn't give details about pattern validation errors.

## Manual Test Cases

For each backend model (Game, ShoppingList, ShoppingListItem), check the backend code/docs to see what validations are performed on the model. Then, try out the creation and edit forms for those models, using valid and invalid values for each field. Make sure to trigger each validation error (e.g., for games, try submitting once with no name and once with a name with invalid characters). Note that uniqueness validations are currently _not_ handled through these form validations, so you do not need to check those.

Don't forget the shopping list edit form and the modal game creation form (which can be brought up on the shopping list page but only if you have no games).

## Screenshots and GIFs

One example of a validation (in Chrome - Safari doesn't provide such useful messages, unfortunately):

<img width="642" alt="Screen Shot 2021-08-05 at 8 20 18 am" src="https://user-images.githubusercontent.com/5115928/128264691-9fe19af5-9e40-49ef-8bc8-b4f58376ec55.png">

