### PR TITLE
Fix bug with form validations

### DIFF
--- a/src/components/gameCreateForm/gameCreateForm.js
+++ b/src/components/gameCreateForm/gameCreateForm.js
@@ -74,7 +74,6 @@ const GameCreateForm = ({ disabled }) => {
                   aria-label='Name'
                   pattern="^\s*[A-Za-z0-9 \-',]*\s*$"
                   title="Name can contain only alphanumeric characters, spaces, commas, hyphens, and apostrophes"
-                  required
                 />
               </fieldset>
               <fieldset className={classNames(styles.fieldset, { [styles.fieldsetDisabled]: disabled })} disabled={disabled}>

--- a/src/components/modalGameForm/modalGameForm.js
+++ b/src/components/modalGameForm/modalGameForm.js
@@ -13,7 +13,6 @@ const formFields = [
     type: 'text',
     placeholder: 'Name',
     inputMode: 'text',
-    required: true,
     pattern: "^\\s*[A-Za-z0-9 \\-',]*\\s*$",
     title: 'Name can only contain alphanumeric characters, spaces, commas, hyphens, and apostrophes'
   },

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -57,7 +57,6 @@ const ShoppingListCreateForm = ({ disabled }) => {
             onChange={updateValue}
             pattern="^\s*[A-Za-z0-9 \-',]*\s*$"
             title='Title can only contain alphanumeric characters, spaces, commas, hyphens, and apostrophes'
-            required
           />
           <button className={classNames(styles.button, { [styles.buttonDisabled]: disabled })} type='submit'>Create</button>
         </fieldset>

--- a/src/components/shoppingListEditForm/shoppingListEditForm.js
+++ b/src/components/shoppingListEditForm/shoppingListEditForm.js
@@ -68,7 +68,6 @@ const ShoppingListEditForm = ({ formRef, maxTotalWidth, className, title, onSubm
         value={inputValue}
         pattern="^\s*[A-Za-z0-9 \-',]*\s*$"
         title='Title can only contain alphanumeric characters, spaces, hyphens, commas, and apostrophes'
-        required
       />
       <button className={styles.submit} ref={buttonRef} name='submit' type='submit'>
         <FontAwesomeIcon className={styles.fa} icon={faCheckSquare} />

--- a/src/pages/gamesPage/__tests__/createGame.test.js
+++ b/src/pages/gamesPage/__tests__/createGame.test.js
@@ -88,33 +88,6 @@ describe('Creating a game on the games page', () => {
   // forgotten about.
 
   // describe('form validation errors', () => {
-  //   it("doesn't submit without a name", async () => {
-  //     component = renderComponentWithMockCookies()
-
-  //     // Click the link that triggers the create form to become visible
-  //     const toggleLink = await screen.findByText('Create Game...')
-  //     fireEvent.click(toggleLink)
-
-  //     // Fill out and submit the creation form, leaving the name blank
-  //     const nameInput = await screen.findByLabelText('Name')
-  //     const descInput = await screen.findByLabelText('Description')
-  //     const form = await screen.findByTestId('game-create-form')
-
-  //     fireEvent.change(nameInput, { target: { value: '' } })
-  //     fireEvent.change(descInput, { target: { value: 'New game description' } })
-  //     fireEvent.submit(form)
-
-  //     // The form should not be reset or hidden
-  //     await waitFor(() => expect(form).toBeVisible())
-  //     await waitFor(() => expect(screen.queryByDisplayValue('New game description')).toBeVisible())
-
-  //     // The flash message should not be visible. A validation error should not show up
-  //     // and neither should the CORS error that will be returned if the form submits
-  //     // during this test since no API request handler is defined.
-  //     await waitFor(() => expect(screen.queryByText(/error\(s\)/)).not.toBeInTheDocument())
-  //     await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
-  //   })
-
   //   it("doesn't submit with an invalid name", async () => {
   //     component = renderComponentWithMockCookies()
 

--- a/src/pages/gamesPage/__tests__/editGame.test.js
+++ b/src/pages/gamesPage/__tests__/editGame.test.js
@@ -167,44 +167,6 @@ describe('Editing a game on the games page', () => {
   // describe('form validations', () => {
   //   const { name, description } = games[0]
 
-  //   it("doesn't submit without a name", async () => {
-  //     component = renderComponentWithMockCookies()
-
-  //     const gameTitle = await screen.findByText(name)
-  //     const gameEl = gameTitle.closest('.root')
-
-  //     // The icon you click to display the form
-  //     const editIcon = await within(gameEl).findByTestId('game-edit-icon')
-
-  //     // Display the edit form
-  //     fireEvent.click(editIcon)
-
-  //     const form = await screen.findByTestId('game-form')
-  //     const nameInput = await within(form).findByDisplayValue(name)
-  //     const descInput = await within(form).findByDisplayValue(description)
-
-  //     // Fill out the inputs
-  //     fireEvent.change(nameInput, { target: { value: '' } })
-  //     fireEvent.change(descInput, { target: { value: 'New description' } })
-
-  //     // Submit the edit form
-  //     fireEvent.submit(form)
-
-  //     // Form should be visible and not cleared
-  //     await waitFor(() => expect(form).toBeVisible())
-  //     await waitFor(() => expect(screen.queryByDisplayValue('New description')).toBeVisible())
-
-  //     // The game should still appear in the list under its old name
-  //     await waitFor(() => expect(screen.queryByText(name)).toBeVisible())
-
-  //     // No flash message should be displayed, either for the validation error
-  //     // or for the CORS error that will be raised if this test makes an API
-  //     // request (since it isn't expected to)
-  //     await waitFor(() => expect(screen.queryByText(/success/i)).not.toBeInTheDocument())
-  //     await waitFor(() => expect(screen.queryByText(/error\(s\)/i)).not.toBeInTheDocument())
-  //     await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).not.toBeInTheDocument())
-  //   })
-
   //   it("doesn't submit with an invalid name", async () => {
   //     component = renderComponentWithMockCookies()
 


### PR DESCRIPTION
## Context

[**Add front-end form validations**](https://trello.com/c/prvOfEaT/133-add-front-end-form-validations)

When I made the [first PR](https://github.com/danascheider/skyrim_inventory_management_frontend/pull/122) for form validations, I forgot that games and shopping lists are allowed to have blank names & titles since the back end automatically assigns a name or title to a model without one. I made those fields required on the forms when they shouldn't be. This PR fixes that.

## Changes

* Make `Game#name` and `ShoppingList#title` optional fields on forms
* Remove commented-out tests that tested these forms being required so we know not to uncomment/reimplement those ones when we're able to
