### PR TITLE
Redesign flash messages

### DIFF
--- a/docs/contexts/app-context.md
+++ b/docs/contexts/app-context.md
@@ -11,9 +11,9 @@ The `AppProvider`'s value includes the following:
 * `profileLoadState`: The status of profile data loading, either 'loading' or 'done'
 * `setShouldRedirectTo`: A setter function that immediately causes the user to be redirected to the path passed in. If you are logging the user out, you should use the `logOutAndRedirect` function instead.
 * `logOutAndRedirect`: A function that logs the user out with Google, redirects to the `path` passed in, unmounts the context provider, and runs a callback function if one is given. The callback function takes no arguments and can be used to clean up refs/unmount consumer components following the redirect.
-* `flashProps`: The props with which to render the flash message element (if any)
+* `flashAttributes`: The attributes of the flash message, if any, that should be displayed, including `type` ('error', 'info', 'success', or 'warning'), `header`, and `message` that will be rendered by the `FlashMessage` component
 * `flashVisible`: Whether the flash message element (if any) should be visible on the page
-* `setFlashProps`: A function that enables you to set the type ('error', 'info', or 'success'), message, and header of the `FlashMessage` component (consumers are responsible for rendering the flash message)
+* `setFlashAttributes`: A function that enables you to set the type ('error', 'info', 'success', or 'warning'), message, and header of the `FlashMessage` component (consumers are responsible for rendering the flash message)
 * `setFlashVisible`: A function that enables you to set the `flashVisible` value to `true` or `false`
 * `modalVisible`: A boolean value indicating whether a modal, if it is present on the page, should be shown
 * `modalAttributes`: An object indicating the component the modal should display as well as the props that should be passed through to the modal component

--- a/src/components/flashMessage/flashMessage.js
+++ b/src/components/flashMessage/flashMessage.js
@@ -16,9 +16,9 @@ const colors = {
 }
 
 const FlashMessage = () => {
-  const { flashVisible, setFlashVisible, flashProps } = useAppContext()
+  const { flashVisible, setFlashVisible, flashAttributes } = useAppContext()
 
-  const { type, header, message } = flashProps
+  const { type, header, message } = flashAttributes
 
   const colorVars = { '--text-color': colors[type] }
 

--- a/src/components/flashMessage/flashMessage.js
+++ b/src/components/flashMessage/flashMessage.js
@@ -1,5 +1,6 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React, { useEffect } from 'react'
+import classNames from 'classnames'
+import { useAppContext } from '../../hooks/contexts'
 import styles from './flashMessage.module.css'
 
 const SUCCESS = 'success'
@@ -8,37 +9,29 @@ const ERROR = 'error'
 const WARNING = 'warning'
 
 const colors = {
-  [SUCCESS]: {
-    body: '#e5f2e5',
-    border: '#b2d8b2',
-    text: '#329932'
-  },
-  [INFO]: {
-    body: '#cce5ff',
-    border: '#b3d8ff',
-    text: '#4e6d8e',
-  },
-  [ERROR]: {
-    body: '#ffcccc',
-    border: '#ff9999',
-    text: '#cc0000'
-  },
-  [WARNING]: {
-    body: '#fefde4',
-    border: '#fdf797',
-    text: '#b0a723'
-  }
+  [SUCCESS]: '#329932',
+  [INFO]: '#4e6d8e',
+  [ERROR]: '#cc0000',
+  [WARNING]: '#b0a723'
 }
 
-const FlashMessage = ({ type = INFO, header, message }) => {
-  const colorVars = {
-    '--body-color': colors[type].body,
-    '--border-color': colors[type].border,
-    '--text-color': colors[type].text
-  }
+const FlashMessage = () => {
+  const { flashVisible, setFlashVisible, flashProps } = useAppContext()
+
+  const { type, header, message } = flashProps
+
+  const colorVars = { '--text-color': colors[type] }
+
+  useEffect(() => {
+    if (flashVisible) {
+      setTimeout(() => {
+        setFlashVisible(false)
+      }, 4000)
+    }
+  }, [flashVisible, setFlashVisible])
 
   return(
-    <div className={styles.root} style={colorVars}>
+    <div className={classNames(styles.root, { [styles.hidden]: !flashVisible })} style={colorVars}>
       {header && <p className={styles.header}>{header}</p>}
       {typeof message === 'string' ? message :
       <ul className={styles.messageList}>
@@ -46,14 +39,6 @@ const FlashMessage = ({ type = INFO, header, message }) => {
       </ul>}
     </div>
   )
-}
-
-FlashMessage.propTypes = {
-  type: PropTypes.oneOf([SUCCESS, INFO, ERROR, WARNING]),
-  header: PropTypes.string,
-  message: PropTypes.oneOfType([
-    PropTypes.string, PropTypes.arrayOf(PropTypes.string)
-  ]).isRequired
 }
 
 export default FlashMessage

--- a/src/components/flashMessage/flashMessage.module.css
+++ b/src/components/flashMessage/flashMessage.module.css
@@ -2,13 +2,25 @@
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
   font-size: 1.1rem;
   line-height: 1.25;
-  background-color: var(--body-color);
+  background-color: rgba(255,255,255,0.92);
   color: var(--text-color);
-  border: 1px solid var(--border-color);
+  border: 1px solid #dedede;
   padding: 16px;
   text-align: center;
   border-radius: 8px;
-  margin: 0 auto;
+  box-shadow: 1px 1px 8px #dedede;
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 128px;
+  z-index: 1001;
+  width: 82%;
+}
+
+.hidden {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 300ms linear,visibility 300ms linear;
 }
 
 .content {
@@ -29,14 +41,26 @@
   list-style-position: inside;
 }
 
+@media (min-width: 601px) {
+  .root {
+    max-width: 50%;
+  }
+}
+
 @media (min-width: 769px) {
   .root {
-    max-width: 60%;
+    max-width: 40%;
   }
 }
 
 @media (min-width: 1025px) {
   .root {
     max-width: 30%;
+  }
+}
+
+@media (min-width: 1201px) {
+  .root {
+    max-width: 20%;
   }
 }

--- a/src/components/flashMessage/flashMessage.module.css
+++ b/src/components/flashMessage/flashMessage.module.css
@@ -25,6 +25,7 @@
 
 .content {
   margin: 0 auto; 
+  line-height: 1.25;
 }
 
 .header {

--- a/src/components/flashMessage/flashMessage.stories.js
+++ b/src/components/flashMessage/flashMessage.stories.js
@@ -10,7 +10,7 @@ export const Success = () => (
     overrideValue={{
       profileData,
       flashVisible: true,
-      flashProps: {
+      flashAttributes: {
         type: 'success',
         header: 'Success!',
         message: 'You have succeeded.'
@@ -27,7 +27,7 @@ export const Info = () => (
     overrideValue={{
       profileData,
       flashVisible: true,
-      flashProps: {
+      flashAttributes: {
         type: 'info',
         header: 'Just so you know:',
         message: 'Your changes have been saved.'
@@ -43,7 +43,7 @@ export const InfoNoHeader = () => (
     overrideValue={{
       profileData,
       flashVisible: true,
-      flashProps: {
+      flashAttributes: {
         type: 'info',
         message: 'Your changes have been saved.'
       }
@@ -58,7 +58,7 @@ export const Warning = () => (
     overrideValue={{
       profileData,
       flashVisible: true,
-      flashProps: {
+      flashAttributes: {
         type: 'warning',
         header: "I'm warning you:",
         message: 'Your changes have not been saved.'
@@ -74,7 +74,7 @@ export const Error = () => (
     overrideValue={{
       profileData,
       flashVisible: true,
-      flashProps: {
+      flashAttributes: {
         type: 'error',
         header: 'There was an error saving your changes:',
         message: 'Title cannot be blank.'
@@ -90,7 +90,7 @@ export const ErrorMultiple = () => (
     overrideValue={{
       profileData,
       flashVisible: true,
-      flashProps: {
+      flashAttributes: {
         type: 'error',
         header: 'There were errors saving your changes:',
         message: ['Title cannot be blank', 'You are a nerd']

--- a/src/components/flashMessage/flashMessage.stories.js
+++ b/src/components/flashMessage/flashMessage.stories.js
@@ -1,47 +1,102 @@
 import React from 'react'
+import { AppProvider } from '../../contexts/appContext'
+import { profileData } from '../../sharedTestData'
 import FlashMessage from './flashMessage'
 
 export default { title: 'FlashMessage' }
 
 export const Success = () => (
-  <FlashMessage
-    type='success'
-    header='Success!'
-    message='You have succeeded.'
-  />
+  <AppProvider
+    overrideValue={{
+      profileData,
+      flashVisible: true,
+      flashProps: {
+        type: 'success',
+        header: 'Success!',
+        message: 'You have succeeded.'
+      }
+    }}
+  >
+    <FlashMessage />
+  </AppProvider>
 )
 
 
 export const Info = () => (
-  <FlashMessage
-    type='info'
-    header='Just so you know:'
-    message='Your changes have been saved.'
-  />
+  <AppProvider
+    overrideValue={{
+      profileData,
+      flashVisible: true,
+      flashProps: {
+        type: 'info',
+        header: 'Just so you know:',
+        message: 'Your changes have been saved.'
+      }
+    }}
+  >
+    <FlashMessage />
+  </AppProvider>
 )
 
-export const InfoNoHeader = () => <FlashMessage type='info' message='Your changes have been saved.' />
+export const InfoNoHeader = () => (
+  <AppProvider
+    overrideValue={{
+      profileData,
+      flashVisible: true,
+      flashProps: {
+        type: 'info',
+        message: 'Your changes have been saved.'
+      }
+    }}
+  >
+    <FlashMessage />
+  </AppProvider>
+)
 
 export const Warning = () => (
-  <FlashMessage
-    type='warning'
-    header="I'm warning you:"
-    message='Your changes have not been saved.'
-  />
+  <AppProvider
+    overrideValue={{
+      profileData,
+      flashVisible: true,
+      flashProps: {
+        type: 'warning',
+        header: "I'm warning you:",
+        message: 'Your changes have not been saved.'
+      }
+    }}
+  >
+    <FlashMessage />
+  </AppProvider>
 )
 
 export const Error = () => (
-  <FlashMessage
-    type='error'
-    header='There was an error saving your changes:'
-    message='Title cannot be blank'
-  />
+  <AppProvider
+    overrideValue={{
+      profileData,
+      flashVisible: true,
+      flashProps: {
+        type: 'error',
+        header: 'There was an error saving your changes:',
+        message: 'Title cannot be blank.'
+      }
+    }}
+  >
+    <FlashMessage />
+  </AppProvider>
 )
 
 export const ErrorMultiple = () => (
-  <FlashMessage
-    type='error'
-    header='There were errors saving your changes:'
-    message={['Title cannot be blank', 'You are a nerd']}
-  />
+  <AppProvider
+    overrideValue={{
+      profileData,
+      flashVisible: true,
+      flashProps: {
+        type: 'error',
+        header: 'There were errors saving your changes:',
+        message: ['Title cannot be blank', 'You are a nerd']
+      }
+    }}
+  >
+    <FlashMessage />
+  </AppProvider>
 )

--- a/src/components/game/game.js
+++ b/src/components/game/game.js
@@ -16,7 +16,7 @@ const Game = ({ gameId, name, description }) => {
   const [toggleEvent, setToggleEvent] = useState(0)
 
   const {
-    setFlashProps,
+    setFlashAttributes,
     setFlashVisible,
     setModalVisible,
     setModalAttributes
@@ -69,7 +69,7 @@ const Game = ({ gameId, name, description }) => {
 
       performGameDestroy(gameId, callbacks)
     } else {
-      setFlashProps({
+      setFlashAttributes({
         type: 'info',
         message: 'Your game was not deleted.'
       })

--- a/src/components/loadingError/loadingError.js
+++ b/src/components/loadingError/loadingError.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styles from './loadingError.module.css'
+
+const LoadingError = ({ modelName }) => (
+  <div className={styles.root}>
+    <p className={styles.text}>
+      There was an error loading your {modelName}. It may have been on our end. We're sorry!
+    </p>
+  </div>
+)
+
+LoadingError.propTypes = {
+  modelName: PropTypes.oneOf(['games', 'shopping lists'])
+}
+
+export default LoadingError

--- a/src/components/loadingError/loadingError.module.css
+++ b/src/components/loadingError/loadingError.module.css
@@ -1,0 +1,40 @@
+.root {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  color: #cc0000;
+  font-size: 1.025rem;
+  background-color: #ffcccc;
+  border: 1px solid #ff9999;
+  border-radius: 8px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.text {
+  margin: 0;
+  line-height: 1.25;
+}
+
+@media (min-width: 601px) {
+  .root {
+    max-width: 60%;
+  }
+}
+
+@media (min-width: 769px) {
+  .root {
+    font-size: 1.125rem;
+    max-width: 50%;
+  }
+}
+
+@media (min-width: 1025px) {
+  .root {
+    max-width: 40%;
+  }
+}
+
+@media (min-width: 1201px) {
+  .root {
+    max-width: 30%
+  }
+}

--- a/src/components/loadingError/loadingError.stories.js
+++ b/src/components/loadingError/loadingError.stories.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import LoadingError from './loadingError'
+
+export default { title: 'LoadingError' }
+
+export const Games = () => <LoadingError modelName='games' />
+
+export const ShoppingLists = () => <LoadingError modelName='shopping lists' />

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -41,7 +41,7 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
 
   const { componentRef, triggerRef, isComponentVisible, setIsComponentVisible } = useComponentVisible()
 
-  const { setFlashProps, setFlashVisible } = useAppContext()
+  const { setFlashAttributes, setFlashVisible } = useAppContext()
 
   const {
     shoppingLists,
@@ -123,7 +123,7 @@ const ShoppingList = ({ canEdit = true, listId, title}) => {
 
       performShoppingListDestroy(listId, { onSuccess, onNotFound: onError, onInternalServerError: onError })
     } else if (mountedRef.current) {
-      setFlashProps({
+      setFlashAttributes({
         type: 'info',
         message: 'Your list was not deleted.'
       })

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.js
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.js
@@ -35,7 +35,7 @@ const ShoppingListCreateForm = ({ disabled }) => {
     }
 
     const callbacks = {
-      onSuccess: () => setInputValue(''),
+      onSuccess: showFlashAndClearInput,
       onNotFound: showFlashAndClearInput,
       onUnprocessableEntity: () => setFlashVisible(true),
       onInternalServerError: showFlashAndClearInput

--- a/src/components/shoppingListItem/shoppingListItem.js
+++ b/src/components/shoppingListItem/shoppingListItem.js
@@ -26,7 +26,7 @@ const ShoppingListItem = ({
   const [currentQuantity, setCurrentQuantity] = useState(quantity)
 
   const {
-    setFlashProps,
+    setFlashAttributes,
     setFlashVisible,
     setModalVisible,
     setModalAttributes
@@ -72,7 +72,7 @@ const ShoppingListItem = ({
 
   const displayFlash = (type, message, header = null) => {
     if (mountedRef.current) {
-      setFlashProps({ type, message, header })
+      setFlashAttributes({ type, message, header })
       setFlashVisible(true)
     }
   }

--- a/src/components/shoppingListsPageContent/shoppingListsPageContent.js
+++ b/src/components/shoppingListsPageContent/shoppingListsPageContent.js
@@ -5,11 +5,12 @@ import withModal from '../../hocs/withModal'
 import { ColorProvider } from '../../contexts/colorContext'
 import { shoppingListLoadingStates } from '../../contexts/shoppingListsContext'
 import Loading from '../loading/loading'
+import LoadingError from '../loadingError/loadingError'
 import ShoppingList from '../shoppingList/shoppingList'
 import ModalGameForm from '../modalGameForm/modalGameForm'
 import styles from './shoppingListsPageContent.module.css'
 
-const { LOADING, DONE } = shoppingListLoadingStates
+const { LOADING, ERROR, DONE } = shoppingListLoadingStates
 
 const ShoppingListsPageContent = () => {
   const { setModalAttributes, setModalVisible } = useAppContext()
@@ -84,6 +85,10 @@ const ShoppingListsPageContent = () => {
     return <p className={styles.noLists}>This game has no shopping lists.</p>
   } else if (shoppingListLoadingState === LOADING) {
     return <Loading className={styles.loading} color={YELLOW.schemeColorDarkest} height='15%' width='15%' />
+  } else if (gameLoadingState === ERROR || shoppingListLoadingState === ERROR) {
+    // It's possible both are errored but we'll worry about games first
+    const name = gameLoadingState === ERROR ? 'games' : 'shopping lists'
+    return <LoadingError modelName={name} />
   } else {
     return null
   }

--- a/src/components/shoppingListsPageContent/shoppingListsPageContent.js
+++ b/src/components/shoppingListsPageContent/shoppingListsPageContent.js
@@ -3,14 +3,12 @@ import colorSchemes, { YELLOW } from '../../utils/colorSchemes'
 import { useAppContext, useGamesContext, useShoppingListsContext } from '../../hooks/contexts'
 import withModal from '../../hocs/withModal'
 import { ColorProvider } from '../../contexts/colorContext'
-import { shoppingListLoadingStates } from '../../contexts/shoppingListsContext'
+import { LOADING, DONE, ERROR } from '../../utils/loadingStates'
 import Loading from '../loading/loading'
 import LoadingError from '../loadingError/loadingError'
 import ShoppingList from '../shoppingList/shoppingList'
 import ModalGameForm from '../modalGameForm/modalGameForm'
 import styles from './shoppingListsPageContent.module.css'
-
-const { LOADING, ERROR, DONE } = shoppingListLoadingStates
 
 const ShoppingListsPageContent = () => {
   const { setModalAttributes, setModalVisible } = useAppContext()

--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -34,7 +34,7 @@ const AppProvider = ({ children, overrideValue = {} }) => {
   const { pathname } = useLocation()
   const [cookies, setCookie, removeCookie] = useCookies([sessionCookieName])
 
-  const [flashProps, setFlashProps] = useState({ type: 'info', message: '' })
+  const [flashAttributes, setFlashAttributes] = useState({ type: 'info', message: '' })
   const [flashVisible, setFlashVisible] = useState(false)
 
   const [modalAttributes, setModalAttributes] = useState({})
@@ -79,9 +79,9 @@ const AppProvider = ({ children, overrideValue = {} }) => {
     setShouldRedirectTo,
     logOutAndRedirect,
     flashVisible,
-    flashProps,
+    flashAttributes,
     setFlashVisible,
-    setFlashProps,
+    setFlashAttributes,
     setModalVisible,
     setModalAttributes,
     modalVisible,
@@ -152,13 +152,13 @@ AppProvider.propTypes = {
     removeSessionCookie: PropTypes.func,
     setProfileData: PropTypes.func,
     flashVisible: PropTypes.bool,
-    flashProps: PropTypes.shape({
+    flashAttributes: PropTypes.shape({
       type: PropTypes.oneOf(['error', 'info', 'success']).isRequired,
       message: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]).isRequired,
       header: PropTypes.string
     }),
     setFlashVisible: PropTypes.func,
-    setFlashProps: PropTypes.func,
+    setFlashAttributes: PropTypes.func,
     logOutAndRedirect: PropTypes.func,
     setModalVisible: PropTypes.func,
     setModalAttributes: PropTypes.func,

--- a/src/contexts/appContext.js
+++ b/src/contexts/appContext.js
@@ -34,7 +34,7 @@ const AppProvider = ({ children, overrideValue = {} }) => {
   const { pathname } = useLocation()
   const [cookies, setCookie, removeCookie] = useCookies([sessionCookieName])
 
-  const [flashProps, setFlashProps] = useState({})
+  const [flashProps, setFlashProps] = useState({ type: 'info', message: '' })
   const [flashVisible, setFlashVisible] = useState(false)
 
   const [modalAttributes, setModalAttributes] = useState({})

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -18,14 +18,9 @@ import {
   updateGame,
   destroyGame
 } from '../utils/simApi'
+import { LOADING, DONE, ERROR } from '../utils/loadingStates'
 import { useAppContext } from '../hooks/contexts'
 import paths from '../routing/paths'
-
-const LOADING = 'loading'
-const DONE = 'done'
-const ERROR = 'error'
-
-const gameLoadingStates = { LOADING, DONE, ERROR }
 
 const GamesContext = createContext()
 
@@ -261,4 +256,4 @@ GamesProvider.propTypes = {
   })
 }
 
-export { GamesContext, GamesProvider, gameLoadingStates }
+export { GamesContext, GamesProvider }

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -66,14 +66,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           } else {
             if (process.env.NODE_ENV === 'development') console.error('Unexpected error fetching games: ', err)
 
-            if (mountedRef.current) {
-              setFlashAttributes({
-                type: 'error',
-                message: "There was an error loading your games. It may have been on our end. We're sorry!"
-              })
-
-              setGameLoadingState(ERROR)
-            }
+            if (mountedRef.current) setGameLoadingState(ERROR)
           }
         })
     }

--- a/src/contexts/gamesContext.js
+++ b/src/contexts/gamesContext.js
@@ -30,7 +30,7 @@ const gameLoadingStates = { LOADING, DONE, ERROR }
 const GamesContext = createContext()
 
 const GamesProvider = ({ children, overrideValue = {} }) => {
-  const { token, logOutAndRedirect, setFlashProps } = useAppContext()
+  const { token, logOutAndRedirect, setFlashAttributes } = useAppContext()
 
   const [games, setGames] = useState(overrideValue.games || [])
   const [gameLoadingState, setGameLoadingState] = useState(overrideValue.gameLoadingState || LOADING)
@@ -67,7 +67,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
             if (process.env.NODE_ENV === 'development') console.error('Unexpected error fetching games: ', err)
 
             if (mountedRef.current) {
-              setFlashProps({
+              setFlashAttributes({
                 type: 'error',
                 message: "There was an error loading your games. It may have been on our end. We're sorry!"
               })
@@ -77,7 +77,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           }
         })
     }
-  }, [token, overrideValue.gameLoadingState, setFlashProps, logOutAndRedirect])
+  }, [token, overrideValue.gameLoadingState, setFlashAttributes, logOutAndRedirect])
 
   const performGameCreate = useCallback((attrs, callbacks) => {
     const { onSuccess, onUnprocessableEntity, onUnauthorized, onInternalServerError } = callbacks
@@ -91,14 +91,14 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
             setGames(newGames)
           }
 
-          setFlashProps({
+          setFlashAttributes({
             type: 'success',
             message: 'Success! Your game has been created.'
           })
 
           onSuccess && onSuccess()
         } else if (status === 422) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             header: `${json.errors.length} error(s) prevented your game from being created:`,
             message: json.errors
@@ -119,7 +119,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
         } else {
           if (process.env.NODE_ENV === 'development') console.error('Error creating game: ', err)
 
-          mountedRef.current && setFlashProps({
+          mountedRef.current && setFlashAttributes({
             type: 'error',
             message: "Something unexpected happened while creating your game. Unfortunately, we don't know more than that yet. We're working on it!"
           })
@@ -127,7 +127,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           onInternalServerError && onInternalServerError()
         }
       })
-  }, [token, games, setFlashProps, logOutAndRedirect])
+  }, [token, games, setFlashAttributes, logOutAndRedirect])
 
   const performGameUpdate = useCallback((gameId, attrs, callbacks) => {
     const { onSuccess, onUnprocessableEntity, onNotFound, onInternalServerError, onUnauthorized } = callbacks
@@ -138,13 +138,13 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           if (mountedRef.current) {
             const newGames = games.map(game => parseInt(game.id) === parseInt(gameId) ? json : game)
             setGames(newGames)
-            setFlashProps({ type: 'success', message: 'Success! Your game has been updated.' })
+            setFlashAttributes({ type: 'success', message: 'Success! Your game has been updated.' })
           }
 
           onSuccess && onSuccess()
         } else if (status === 422) {
           if (mountedRef.current) {
-            setFlashProps({
+            setFlashAttributes({
               type: 'error',
               message: json.errors,
               header: `${json.errors.length} error(s) prevented your game from being updated:`
@@ -163,7 +163,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
             onUnauthorized && onUnauthorized()
           })
         } else if (err.code === 404) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Oops! We couldn't find the game you wanted to update. Sorry! Try refreshing the page to solve this problem."
           })
@@ -172,7 +172,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
         } else {
           if (process.env.NODE_ENV === 'development') console.error('Error updating game: ', err)
 
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Something unexpected happened while trying to update your game. Unfortunately, we don't know more than that yet. We're working on it!"
           })
@@ -180,7 +180,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           onInternalServerError && onInternalServerError()
         }
       })
-  }, [token, games, setFlashProps, logOutAndRedirect])
+  }, [token, games, setFlashAttributes, logOutAndRedirect])
 
   const performGameDestroy = useCallback((gameId, callbacks) => {
     const { onSuccess, onUnauthorized, onInternalServerError } = callbacks
@@ -197,7 +197,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           newGames.splice(gameIndex, 1)
 
           setGames(newGames)
-          setFlashProps({
+          setFlashAttributes({
             type: 'success',
             message: 'Your game has been deleted.'
           })
@@ -217,7 +217,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           if (process.env.NODE_ENV === 'development') console.error('Error destroying game: ', err)
 
           if (mountedRef.current) {
-            setFlashProps({
+            setFlashAttributes({
               type: 'error',
               message: "Something unexpected happened while trying to delete your game. Unfortunately, we don't know more than that yet. We're working on it!"
             })
@@ -226,7 +226,7 @@ const GamesProvider = ({ children, overrideValue = {} }) => {
           onInternalServerError && onInternalServerError()
         }
       })
-  }, [token, games, logOutAndRedirect, setFlashProps])
+  }, [token, games, logOutAndRedirect, setFlashAttributes])
 
   const value = {
     games,

--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -137,10 +137,6 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             if (process.env.NODE_ENV === 'development') console.error('Unexpected error fetching shopping lists: ', err)
 
             if (mountedRef.current) {
-              setFlashAttributes({
-                type: 'error',
-                message: "There was an unexpected error loading your lists. It may have been on our end. We're sorry!"
-              })
               !overrideValue.shoppingListLoadingState && setShoppingListLoadingState(ERROR)
             }
           }

--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -46,7 +46,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
   const {
     token,
     logOutAndRedirect,
-    setFlashProps,
+    setFlashAttributes,
     setFlashVisible
   } = useAppContext()
 
@@ -125,7 +125,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             logOutAndRedirect(paths.login, () => mountedRef.current = false)
             // Don't set the loading state because it's redirecting anyway
           } else if (err.code === 404 && mountedRef.current) {
-            setFlashProps({
+            setFlashAttributes({
               type: 'error',
               message: "We couldn't find the game you're looking for."
             })
@@ -137,7 +137,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             if (process.env.NODE_ENV === 'development') console.error('Unexpected error fetching shopping lists: ', err)
 
             if (mountedRef.current) {
-              setFlashProps({
+              setFlashAttributes({
                 type: 'error',
                 message: "There was an unexpected error loading your lists. It may have been on our end. We're sorry!"
               })
@@ -148,7 +148,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
     } else {
       mountedRef.current && !overrideValue.shoppingListLoadingState && setShoppingListLoadingState(DONE)
     }
-  }, [token, overrideValue.shoppingListLoadingState, setFlashProps, setFlashVisible, activeGameId, logOutAndRedirect])
+  }, [token, overrideValue.shoppingListLoadingState, setFlashAttributes, setFlashVisible, activeGameId, logOutAndRedirect])
 
   const performShoppingListUpdate = (listId, newTitle, callbacks = {}) => {
     const { onSuccess, onNotFound, onUnprocessableEntity, onUnauthorized, onInternalServerError } = callbacks
@@ -163,7 +163,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
           !overrideValue.shoppingListLoadingState && setShoppingListLoadingState(DONE)
           onSuccess && onSuccess()
         } else if (status === 422) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: json.errors,
             header: `${json.errors.length} error(s) prevented your changes from being saved:`
@@ -185,7 +185,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             onUnauthorized && onUnauthorized()
           })
         } else if (err.code === 404) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Oops! The shopping list you wanted to update could not be found. Try refreshing the page to fix this issue."
           })
@@ -194,7 +194,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
           
           onNotFound && onNotFound()
         } else {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Something unexpected happened while trying to update your shopping list. Unfortunately, we don't know more than that yet. We're working on it!"
           })
@@ -226,9 +226,14 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             setShoppingLists(newShoppingLists)
           }
 
+          setFlashAttributes({
+            type: 'success',
+            message: 'Success! Your shopping list was created.',
+          })
+
           onSuccess && onSuccess()
         } else if (status === 422) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: json.errors,
             header: `${json.errors.length} error(s) prevented your shopping list from being created:`
@@ -247,7 +252,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             onUnauthorized && onUnauthorized()
           })
         } else if (err.code === 404) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: 'The game you wanted to create a shopping list for could not be found. Try refreshing the page to fix this issue.'
           })
@@ -256,7 +261,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
         } else {
           if (process.env.NODE_ENV === 'development') console.error('Error creating shopping list: ', err)
           
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Something unexpected happened while trying to create your shopping list. Unfortunately, we don't know more than that yet. We're working on it!"
           })
@@ -278,7 +283,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
           // it and the aggregate list have been destroyed.
           setShoppingLists([])
           
-          setFlashProps({
+          setFlashAttributes({
             type: 'success',
             message: 'Since it was the last list for this game, the "All Items" list has been deleted as well.',
             header: 'Your shopping list has been deleted.'
@@ -293,7 +298,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
 
           setShoppingLists(newShoppingLists)
 
-          setFlashProps({
+          setFlashAttributes({
             type: 'success',
             message: 'Your shopping list has been deleted.'
           })
@@ -311,7 +316,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             onUnauthorized && onUnauthorized()
           })
         } else if (err.code === 404) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Oops! We couldn't find the shopping list you wanted to delete. Sorry! Try refreshing the page to solve this problem."
           })
@@ -320,7 +325,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
         } else {
           if (process.env.NODE_ENV === 'development') console.error('Unexpected error deleting shopping list: ', err.message)
 
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Something unexpected happened while trying to delete your shopping list. Unfortunately, we don't know more than that yet. We're working on it!"
           })
@@ -356,12 +361,12 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
           setShoppingLists(newLists)
 
           if (status === 201) {
-            setFlashProps({
+            setFlashAttributes({
               type: 'success',
               message: 'Success! Your shopping list item has been created.'
             })
           } else {
-            setFlashProps({
+            setFlashAttributes({
               type: 'success',
               message: 'Success! Your new shopping list item has been combined with another item with the same description.'
             })
@@ -369,7 +374,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
 
           onSuccess && onSuccess()
         } else if (status === 422) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: json.errors,
             header: `${json.errors.length} error(s) prevented your shopping list item from being created:`
@@ -388,7 +393,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             onUnauthorized && onUnauthorized()
           })
         } else if (err.code === 404) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Oops! We couldn't find the shopping list you wanted to add an item to. Sorry! Try refreshing the page to solve this problem."
           })
@@ -397,7 +402,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
         } else {
           if (process.env.NODE_ENV === 'development') console.error('Unexpected error when creating shopping list item: ', err.message)
 
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Something unexpected happened while trying to create your shopping list item. Unfortunately, we don't know more than that yet. We're working on it!"
           })
@@ -430,11 +435,11 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
 
           setShoppingLists(newShoppingLists)
 
-          setFlashProps({ type: 'success', message: 'Success! Your shopping list item was updated.' })
+          setFlashAttributes({ type: 'success', message: 'Success! Your shopping list item was updated.' })
 
           onSuccess && onSuccess()
         } else if (status === 422) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: json.errors,
             header: `${json.errors.length} error(s) prevented your shopping list item from being updated:`
@@ -453,7 +458,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             onUnauthorized && onUnauthorized()
           })
         } else if (err.code === 404) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Oops! We couldn't find the shopping list item you wanted to update. Sorry! Try refreshing the page to solve this problem."
           })
@@ -462,7 +467,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
         } else {
           if (process.env.NODE_ENV === 'development') console.error(`Unexpected error editing list item ${itemId}: `, err)
 
-          setFlashProps({
+          setFlashAttributes({
             type: 'error',
             message: "Something unexpected happened while trying to update your shopping list item. Unfortunately, we don't know more than that yet. We're working on it!"
           })
@@ -514,7 +519,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
             onUnauthorized && onUnauthorized()
           })
         } else if (err.code === 404) {
-          setFlashProps({
+          setFlashAttributes({
             type: 'error', 
             message: "Oops! We couldn't find the shopping list item you wanted to delete. Sorry! Try refreshing the page to solve this problem."
           })
@@ -523,7 +528,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
         } else {
           if (process.env.NODE_ENV === 'development') console.error('Unexpected error destroying shopping list item: ', err)
 
-          setFlashProps({
+          setFlashAttributes({
             type: 'error', 
             message: "Something unexpected happened while trying to delete your shopping list item. Unfortunately, we don't know more than that yet. We're working on it!"
           })

--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -28,15 +28,10 @@ import {
   updateShoppingListItem,
   destroyShoppingListItem
 } from '../utils/simApi'
+import { LOADING, DONE, ERROR } from '../utils/loadingStates'
 import { useAppContext, useGamesContext } from '../hooks/contexts'
 import useQuery from '../hooks/useQuery'
 import paths from '../routing/paths'
-
-const LOADING = 'loading'
-const DONE = 'done'
-const ERROR = 'error'
-
-const shoppingListLoadingStates = { LOADING, DONE, ERROR }
 
 const ShoppingListsContext = createContext()
 
@@ -587,4 +582,4 @@ ShoppingListsProvider.propTypes = {
   })
 }
 
-export { ShoppingListsContext, ShoppingListsProvider, shoppingListLoadingStates }
+export { ShoppingListsContext, ShoppingListsProvider }

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { YELLOW } from '../../utils/colorSchemes'
 import { useAppContext, useGamesContext } from '../../hooks/contexts'
 import { gameLoadingStates } from '../../contexts/gamesContext'
@@ -7,6 +7,7 @@ import FlashMessage from '../../components/flashMessage/flashMessage'
 import Game from '../../components/game/game'
 import GameCreateForm from '../../components/gameCreateForm/gameCreateForm'
 import Loading from '../../components/loading/loading'
+import LoadingError from '../../components/loadingError/loadingError'
 import styles from './gamesPage.module.css'
 
 const { LOADING, DONE, ERROR } = gameLoadingStates
@@ -23,14 +24,6 @@ const GamesPage = () => {
     gameLoadingState
   } = useGamesContext()
 
-  useEffect(() => {
-    // Flash message props will be set when the `GamesContext` handles the error.
-    // Displaying the flash message in the context provider left the possibility
-    // that this flash message would be displayed on pages other than this one,
-    // where we don't want it.
-    if (gameLoadingState === ERROR) setFlashVisible(true)
-  }, [gameLoadingState, setFlashVisible])
-
   return(
     <DashboardLayout title='Your Games'>
       {modalVisible && <modalAttributes.Tag {...modalAttributes.props} />}
@@ -42,6 +35,7 @@ const GamesPage = () => {
           {games.map(({ id, name, description }) => <Game key={name} gameId={id} name={name} description={description} />)}
         </div>}
         {gameLoadingState === LOADING && <Loading type='bubbles' className={styles.loading} color={YELLOW.schemeColorDarkest} height='15%' width='15%' />}
+        {gameLoadingState === ERROR && <LoadingError modelName='games' />}
       </div>
     </DashboardLayout>
   )

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -37,7 +37,7 @@ const GamesPage = () => {
     <DashboardLayout title='Your Games'>
       {modalVisible && <modalAttributes.Tag {...modalAttributes.props} />}
       <div className={styles.root}>
-        {flashVisible && Object.keys(flashProps).length && <FlashMessage {...flashProps} />}
+        <FlashMessage />
         {games && games.length === 0 && gameLoadingState === DONE && <p className={styles.noGames}>You have no games.</p>}
         {gameLoadingState === DONE && <GameCreateForm disabled={gameLoadingState === LOADING || gameLoadingState === ERROR} />}
         {games && games.length > 0 && gameLoadingState === DONE && <div className={styles.games}>

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -13,8 +13,6 @@ const { LOADING, DONE, ERROR } = gameLoadingStates
 
 const GamesPage = () => {
   const {
-    flashProps,
-    flashVisible,
     setFlashVisible,
     modalVisible,
     modalAttributes

--- a/src/pages/gamesPage/gamesPage.js
+++ b/src/pages/gamesPage/gamesPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { YELLOW } from '../../utils/colorSchemes'
 import { useAppContext, useGamesContext } from '../../hooks/contexts'
-import { gameLoadingStates } from '../../contexts/gamesContext'
+import { LOADING, DONE, ERROR } from '../../utils/loadingStates'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
 import Game from '../../components/game/game'
@@ -9,8 +9,6 @@ import GameCreateForm from '../../components/gameCreateForm/gameCreateForm'
 import Loading from '../../components/loading/loading'
 import LoadingError from '../../components/loadingError/loadingError'
 import styles from './gamesPage.module.css'
-
-const { LOADING, DONE, ERROR } = gameLoadingStates
 
 const GamesPage = () => {
   const {

--- a/src/pages/shoppingListsPage/__tests__/createList.test.js
+++ b/src/pages/shoppingListsPage/__tests__/createList.test.js
@@ -98,6 +98,9 @@ describe('Creating a shopping list', () => {
       // The aggregate list should be visible on the page
       await waitFor(() => expect(screen.queryByText('All Items')).toBeVisible())
 
+      // A flash success message should be visible on the page
+      await waitFor(() => expect(screen.queryByText(/success/i)).toBeVisible())
+
       // The create form should be cleared and still be enabled
       await waitFor(() => expect(input).not.toBeDisabled())
       await waitFor(() => expect(button).not.toBeDisabled())

--- a/src/pages/shoppingListsPage/__tests__/displayLists.test.js
+++ b/src/pages/shoppingListsPage/__tests__/displayLists.test.js
@@ -375,7 +375,7 @@ describe('Displaying the shopping lists page', () => {
       it('displays an error', async () => {
         component = renderComponentWithMockCookies(cookies, 4582)
 
-        await waitFor(() => expect(screen.queryByText(/unexpected error/i)).toBeVisible())
+        await waitFor(() => expect(screen.queryByText(/there was an error/i)).toBeVisible())
       })
     })
 

--- a/src/pages/shoppingListsPage/shoppingListsPage.js
+++ b/src/pages/shoppingListsPage/shoppingListsPage.js
@@ -35,7 +35,7 @@ const ShoppingListsPage = () => {
   return(
     <DashboardLayout title='Your Shopping Lists' includeGameSelect>
       {modalVisible && <modalAttributes.Tag {...modalAttributes.props} />}
-      {flashVisible && <div className={styles.flash}><FlashMessage {...flashProps} /></div>}
+      <FlashMessage />
       <div className={styles.createForm}><ShoppingListCreateForm disabled={shouldDisableForm} /></div>
       <ShoppingListsPageContent /> {/* This component implements its own loading & error handling behaviour */}
     </DashboardLayout>

--- a/src/pages/shoppingListsPage/shoppingListsPage.js
+++ b/src/pages/shoppingListsPage/shoppingListsPage.js
@@ -23,10 +23,6 @@ const ShoppingListsPage = () => {
 
   const mountedRef = useRef(true)
 
-  useEffect(() => {
-    if (mountedRef.current && shoppingListLoadingState === ERROR) setFlashVisible(true)
-  }, [shoppingListLoadingState, setFlashVisible])
-
   useEffect(() => (
     () => mountedRef.current = false
   ), [])

--- a/src/pages/shoppingListsPage/shoppingListsPage.js
+++ b/src/pages/shoppingListsPage/shoppingListsPage.js
@@ -1,13 +1,11 @@
 import React, { useEffect, useRef } from 'react'
 import { useAppContext, useShoppingListsContext } from '../../hooks/contexts'
-import { shoppingListLoadingStates } from '../../contexts/shoppingListsContext'
+import { LOADING, ERROR } from '../../utils/loadingStates'
 import DashboardLayout from '../../layouts/dashboardLayout'
 import FlashMessage from '../../components/flashMessage/flashMessage'
 import ShoppingListCreateForm from '../../components/shoppingListCreateForm/shoppingListCreateForm'
 import ShoppingListsPageContent from '../../components/shoppingListsPageContent/shoppingListsPageContent'
 import styles from './shoppingListsPage.module.css'
-
-const { LOADING, ERROR } = shoppingListLoadingStates
 
 const ShoppingListsPage = () => {
   const { 

--- a/src/pages/shoppingListsPage/shoppingListsPage.js
+++ b/src/pages/shoppingListsPage/shoppingListsPage.js
@@ -11,7 +11,6 @@ const { LOADING, ERROR } = shoppingListLoadingStates
 
 const ShoppingListsPage = () => {
   const { 
-    flashProps, 
     flashVisible, 
     setFlashVisible,
     modalVisible,

--- a/src/utils/loadingStates.js
+++ b/src/utils/loadingStates.js
@@ -1,0 +1,3 @@
+export const LOADING = 'loading'
+export const DONE = 'done'
+export const ERROR = 'error'


### PR DESCRIPTION
## Context

[**Redesign flash messages**](https://trello.com/c/mi1ybGp3/116-redesign-flash-messages)

The `FlashMessage` component is causing a lot of issues with reflow when it is shown and hidden. Additionally, it's kind of ugly. We needed to redesign the flash message into a fixed-positioned element that would be less obtrusive.

## Changes

* Redesign flash message component to be a fixed-position element
* Hide flash message after 4 seconds when it is shown
* Display flash message on shopping list creation (this was something I'd been meaning to change for a while)
* Change mechanism by which flash is shown or hidden (conditionally adding a class rather than conditionally rendering the component)
* Create `LoadingError` component to be shown instead of flash if games or shopping lists fail to load

## Considerations

I didn't like using the new flash component to display loading errors for games and shopping lists, especially since it now disappears after 4 seconds. So, I designed a new component to be rendered for the error loading state.

These changes have been tested and work well in Safari.

## Manual Test Cases

Walk through any case where a flash message would be shown and make sure it still works and looks good with the new design/disappearing after 4 seconds. Make sure any code that calls `setFlashVisible` runs to make sure everything looks right.

## Screenshots and GIFs

### Short Message, 1201px

![issue-116_1201px](https://user-images.githubusercontent.com/5115928/128434168-8fdcb65e-d2d2-4e2e-a0ba-2499ecbae475.png)

### Short Message, 1025px

![issue-116_1025px](https://user-images.githubusercontent.com/5115928/128434178-60264da9-aaa7-4fea-b2c3-defd8963a171.png)

### Short Message, 769px

![issue-116_769px](https://user-images.githubusercontent.com/5115928/128434186-c4dd2011-5e60-4e7e-bbcb-b5ef7d7c4529.png)

### Short Message, 601px

![issue-116_601px](https://user-images.githubusercontent.com/5115928/128434205-3fa4d0e2-fa59-485d-8f65-73172c5fdebd.png)

### Short Message, 425px

![issue-116_425px](https://user-images.githubusercontent.com/5115928/128434219-1b707b89-7cc5-4334-95c2-a2827bfcfffe.png)

### Long Message, 425px

![issue-116_long-message_425px](https://user-images.githubusercontent.com/5115928/128434246-ab2bebd1-bf6e-423e-a768-5e911958fce3.png)

### Loading Error Component, 1201px

<img width="1169" alt="Screen Shot 2021-08-06 at 10 25 31 am" src="https://user-images.githubusercontent.com/5115928/128437869-bdcc4c6e-807c-48d9-a4a8-11379cfc52ea.png">

### Loading Error Component, 1025px

<img width="992" alt="Screen Shot 2021-08-06 at 10 25 44 am" src="https://user-images.githubusercontent.com/5115928/128437886-1fd6a9ee-cad6-4d59-9b13-a94f652f0606.png">

### Loading Error Component, 769px

<img width="737" alt="Screen Shot 2021-08-06 at 10 25 56 am" src="https://user-images.githubusercontent.com/5115928/128437901-36a35365-6ce6-441d-b0a9-9897fd0216e6.png">

### Loading Error Component, 601px

<img width="568" alt="Screen Shot 2021-08-06 at 10 26 07 am" src="https://user-images.githubusercontent.com/5115928/128437915-bf73c83f-c8a5-4588-a260-669162737612.png">

### Loading Error Component, 425px

<img width="390" alt="Screen Shot 2021-08-06 at 10 26 22 am" src="https://user-images.githubusercontent.com/5115928/128437932-e46ce4a5-3e30-41ac-8664-f55dabb4ee98.png">
