### PR TITLE
Remove unneeded await keywords in tests

### DIFF
--- a/src/pages/dashboardPage/dashboardPage.test.js
+++ b/src/pages/dashboardPage/dashboardPage.test.js
@@ -83,13 +83,13 @@ describe('DashboardPage', () => {
     it('displays the user name', async () => {
       component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><DashboardPage /></AppProvider></CookiesProvider>, { route: '/dashboard' })
 
-      expect(await screen.findByText('Jane Doe')).toBeInTheDocument()
+      await waitFor(() => expect(screen.queryByText('Jane Doe')).toBeVisible())
     })
 
     it('displays the user email', async () => {
       component = renderWithRouter(<CookiesProvider cookies={cookies}><AppProvider><DashboardPage /></AppProvider></CookiesProvider>, { route: '/dashboard' })
 
-      expect(await screen.findByText('dragonborn@gmail.com')).toBeInTheDocument()
+      await waitFor(() => expect(screen.queryByText('dragonborn@gmail.com')).toBeVisible())
     })
 
     it('displays the link to the shopping list page', async () => {

--- a/src/pages/gamesPage/__tests__/createGame.test.js
+++ b/src/pages/gamesPage/__tests__/createGame.test.js
@@ -62,8 +62,8 @@ describe('Creating a game on the games page', () => {
 
       // Fill out and submit the creation form
       const nameInput = await screen.findByLabelText('Name')
-      const descInput = await screen.findByLabelText('Description')
-      const form = await screen.findByTestId('game-create-form')
+      const descInput = screen.getByLabelText('Description')
+      const form = screen.getByTestId('game-create-form')
 
       fireEvent.change(nameInput, { target: { value: 'Another Game' } })
       fireEvent.change(descInput, { target: { value: 'New game description' } })
@@ -141,8 +141,8 @@ describe('Creating a game on the games page', () => {
 
       // Fill out and submit the creation form
       const nameInput = await screen.findByLabelText('Name')
-      const descInput = await screen.findByLabelText('Description')
-      const form = await screen.findByTestId('game-create-form')
+      const descInput = screen.getByLabelText('Description')
+      const form = screen.getByTestId('game-create-form')
 
       fireEvent.change(nameInput, { target: { value: 'Another Game' } })
       fireEvent.change(descInput, { target: { value: 'New game description' } })
@@ -184,8 +184,8 @@ describe('Creating a game on the games page', () => {
 
       // Fill out and submit the creation form
       const nameInput = await screen.findByLabelText('Name')
-      const descInput = await screen.findByLabelText('Description')
-      const form = await screen.findByTestId('game-create-form')
+      const descInput = screen.getByLabelText('Description')
+      const form = screen.getByTestId('game-create-form')
 
       fireEvent.change(nameInput, { target: { value: 'Another Game' } })
       fireEvent.change(descInput, { target: { value: 'New game description' } })
@@ -227,8 +227,8 @@ describe('Creating a game on the games page', () => {
 
       // Fill out and submit the creation form
       const nameInput = await screen.findByLabelText('Name')
-      const descInput = await screen.findByLabelText('Description')
-      const form = await screen.findByTestId('game-create-form')
+      const descInput = screen.getByLabelText('Description')
+      const form = screen.getByTestId('game-create-form')
 
       fireEvent.change(nameInput, { target: { value: 'Another Game' } })
       fireEvent.change(descInput, { target: { value: 'New game description' } })

--- a/src/pages/gamesPage/__tests__/deleteGame.test.js
+++ b/src/pages/gamesPage/__tests__/deleteGame.test.js
@@ -72,7 +72,7 @@ describe('Deleting a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // Find the destroy icon next to the game's title
-      const destroyIcon = await within(gameEl).findByTestId('game-destroy-icon')
+      const destroyIcon = within(gameEl).getByTestId('game-destroy-icon')
 
       // Click the icon
       fireEvent.click(destroyIcon)
@@ -89,7 +89,7 @@ describe('Deleting a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // Find the destroy icon next to the game's title
-      const destroyIcon = await within(gameEl).findByTestId('game-destroy-icon')
+      const destroyIcon = within(gameEl).getByTestId('game-destroy-icon')
 
       // Click the icon
       fireEvent.click(destroyIcon)
@@ -121,7 +121,7 @@ describe('Deleting a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // Find the destroy icon next to the game's title
-      const destroyIcon = await within(gameEl).findByTestId('game-destroy-icon')
+      const destroyIcon = within(gameEl).getByTestId('game-destroy-icon')
 
       // Click the icon
       fireEvent.click(destroyIcon)
@@ -171,7 +171,7 @@ describe('Deleting a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // Find the destroy icon next to the game's title
-      const destroyIcon = await within(gameEl).findByTestId('game-destroy-icon')
+      const destroyIcon = within(gameEl).getByTestId('game-destroy-icon')
 
       // Click the icon
       fireEvent.click(destroyIcon)
@@ -216,7 +216,7 @@ describe('Deleting a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // Find the destroy icon next to the game's title
-      const destroyIcon = await within(gameEl).findByTestId('game-destroy-icon')
+      const destroyIcon = within(gameEl).getByTestId('game-destroy-icon')
 
       // Click the icon
       fireEvent.click(destroyIcon)
@@ -263,7 +263,7 @@ describe('Deleting a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // Find the destroy icon next to the game's title
-      const destroyIcon = await within(gameEl).findByTestId('game-destroy-icon')
+      const destroyIcon = within(gameEl).getByTestId('game-destroy-icon')
 
       // Click the icon
       fireEvent.click(destroyIcon)

--- a/src/pages/gamesPage/__tests__/displayGames.test.js
+++ b/src/pages/gamesPage/__tests__/displayGames.test.js
@@ -134,16 +134,14 @@ describe('Displaying the games page', () => {
         it('displays the games page', async () => {
           component = renderComponentWithMockCookies()
 
-          const el = await screen.findByText(/your games/i)
-
-          expect(el).toBeInTheDocument()
+          await waitFor(() => expect(screen.queryByText(/your games/i)).toBeVisible())
         })
 
         it('displays the list of games', async () => {
           component = renderComponentWithMockCookies()
 
           await waitFor(() => expect(screen.queryByText(games[0].name)).toBeVisible())
-          await waitFor(() => expect(screen.queryByText(games[1].name)).toBeVisible())
+          expect(screen.queryByText(games[1].name)).toBeVisible()
         })
 
         it("doesn't display the 'You have no games' message", async () => {
@@ -162,8 +160,8 @@ describe('Displaying the games page', () => {
           component = renderComponentWithMockCookies()
 
           await waitFor(() => expect(screen.queryByText(games[0].description)).not.toBeVisible())
-          await waitFor(() => expect(screen.queryByText(games[1].description)).not.toBeVisible())
-          await waitFor(() => expect(screen.queryByText('This game has no description.')).not.toBeVisible())
+          expect(screen.queryByText(games[1].description)).not.toBeVisible()
+          expect(screen.queryByText('This game has no description.')).not.toBeVisible()
         })
 
         it('expands one description at a time', async () => {
@@ -174,8 +172,8 @@ describe('Displaying the games page', () => {
           fireEvent.click(titleEl)
 
           await waitFor(() => expect(screen.queryByText(games[0].description)).toBeVisible())
-          await waitFor(() => expect(screen.queryByText(games[1].description)).not.toBeVisible())
-          await waitFor(() => expect(screen.queryByText('This game has no description.')).not.toBeVisible())
+          expect(screen.queryByText(games[1].description)).not.toBeVisible()
+          expect(screen.queryByText('This game has no description.')).not.toBeVisible()
         })
       })
     })

--- a/src/pages/gamesPage/__tests__/editGame.test.js
+++ b/src/pages/gamesPage/__tests__/editGame.test.js
@@ -144,7 +144,7 @@ describe('Editing a game on the games page', () => {
       // Form should be hidden on a successful response
       await waitFor(() => expect(form).not.toBeInTheDocument())
 
-      // The game' should no longer appear in the list under its old name
+      // The game should no longer appear in the list under its old name
       await waitFor(() => expect(screen.queryByText(name)).not.toBeInTheDocument())
 
       // It should be in the list under its new name

--- a/src/pages/gamesPage/__tests__/editGame.test.js
+++ b/src/pages/gamesPage/__tests__/editGame.test.js
@@ -49,14 +49,14 @@ describe('Editing a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // The icon you click to display the form
-      const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+      const editIcon = within(gameEl).getByTestId('game-edit-icon')
 
       // Display the edit form
       fireEvent.click(editIcon)
 
       // The modal and form element should be visible now
       const modal = await screen.findByRole('dialog')
-      const form = await within(modal).findByTestId('game-form')
+      const form = within(modal).getByTestId('game-form')
       expect(form).toBeVisible()
 
       // Press the escape key to hide the modal and form
@@ -77,14 +77,14 @@ describe('Editing a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // The icon you click to display the form
-      const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+      const editIcon = within(gameEl).getByTestId('game-edit-icon')
 
       // Display the edit form
       fireEvent.click(editIcon)
 
       // The modal and form element should be visible now
       const modal = await screen.findByRole('dialog')
-      const form = await within(modal).findByTestId('game-form')
+      const form = within(modal).getByTestId('game-form')
       expect(form).toBeVisible()
 
       // Click on the modal (outside the form)
@@ -125,14 +125,14 @@ describe('Editing a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // The icon you click to display the form
-      const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+      const editIcon = within(gameEl).getByTestId('game-edit-icon')
 
       // Display the edit form
       fireEvent.click(editIcon)
 
       const form = await screen.findByTestId('game-form')
-      const nameInput = await within(form).findByDisplayValue(name)
-      const descInput = await within(form).findByDisplayValue(description)
+      const nameInput = within(form).getByDisplayValue(name)
+      const descInput = within(form).getByDisplayValue(description)
 
       // Fill out the inputs
       fireEvent.change(nameInput, { target: { value: 'Changed Name' } })
@@ -142,10 +142,9 @@ describe('Editing a game on the games page', () => {
       fireEvent.submit(form)
 
       // Form should be hidden on a successful response
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
+      await waitFor(() => expect(form).not.toBeInTheDocument())
 
-      // The game should no longer appear in the list under its old name
+      // The game' should no longer appear in the list under its old name
       await waitFor(() => expect(screen.queryByText(name)).not.toBeInTheDocument())
 
       // It should be in the list under its new name
@@ -228,14 +227,14 @@ describe('Editing a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // The icon you click to display the form
-      const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+      const editIcon = within(gameEl).getByTestId('game-edit-icon')
 
       // Display the edit form
       fireEvent.click(editIcon)
 
       const form = await screen.findByTestId('game-form')
-      const nameInput = await within(form).findByDisplayValue(name)
-      const descInput = await within(form).findByDisplayValue(description)
+      const nameInput = within(form).getByDisplayValue(name)
+      const descInput = within(form).getByDisplayValue(description)
 
       // Fill out the inputs
       fireEvent.change(nameInput, { target: { value: 'Changed Name' } })
@@ -245,8 +244,7 @@ describe('Editing a game on the games page', () => {
       fireEvent.submit(form)
 
       // Form should be hidden
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
+      await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // Flash message should be displayed
       await waitFor(() => expect(screen.queryByText(/couldn't find/i)).toBeVisible())
@@ -255,7 +253,7 @@ describe('Editing a game on the games page', () => {
       await waitFor(() => expect(screen.queryByText('Changed Name')).not.toBeInTheDocument())
 
       // It should be in the list under its original name
-      await waitFor(() => expect(screen.queryByText(name)).toBeVisible())
+      expect(screen.queryByText(name)).toBeVisible()
     })
   })
 
@@ -284,14 +282,14 @@ describe('Editing a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // The icon you click to display the form
-      const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+      const editIcon = within(gameEl).getByTestId('game-edit-icon')
 
       // Display the edit form
       fireEvent.click(editIcon)
 
       const form = await screen.findByTestId('game-form')
-      const nameInput = await within(form).findByDisplayValue(name)
-      const descInput = await within(form).findByDisplayValue(description)
+      const nameInput = within(form).getByDisplayValue(name)
+      const descInput = within(form).getByDisplayValue(description)
 
       // Fill out the inputs
       fireEvent.change(nameInput, { target: { value: 'Changed Name' } })
@@ -341,14 +339,14 @@ describe('Editing a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // The icon you click to display the form
-      const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+      const editIcon = within(gameEl).getByTestId('game-edit-icon')
 
       // Display the edit form
       fireEvent.click(editIcon)
 
       const form = await screen.findByTestId('game-form')
-      const nameInput = await within(form).findByDisplayValue(name)
-      const descInput = await within(form).findByDisplayValue(description)
+      const nameInput = within(form).getByDisplayValue(name)
+      const descInput = within(form).getByDisplayValue(description)
 
       // Fill out the inputs
       fireEvent.change(nameInput, { target: { value: 'Changed Name' } })
@@ -358,8 +356,7 @@ describe('Editing a game on the games page', () => {
       fireEvent.submit(form)
 
       // Form should be hidden
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
+      await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // The game should appear in the list under its old name
       await waitFor(() => expect(gameEl).toHaveTextContent(name))
@@ -394,14 +391,14 @@ describe('Editing a game on the games page', () => {
       const gameEl = gameTitle.closest('.root')
 
       // The icon you click to display the form
-      const editIcon = await within(gameEl).findByTestId('game-edit-icon')
+      const editIcon = within(gameEl).getByTestId('game-edit-icon')
 
       // Display the edit form
       fireEvent.click(editIcon)
 
       const form = await screen.findByTestId('game-form')
-      const nameInput = await within(form).findByDisplayValue(name)
-      const descInput = await within(form).findByDisplayValue(description)
+      const nameInput = within(form).getByDisplayValue(name)
+      const descInput = within(form).getByDisplayValue(description)
 
       // Fill out the inputs
       fireEvent.change(nameInput, { target: { value: 'Changed Name' } })

--- a/src/pages/shoppingListsPage/__tests__/createGameFromLink.test.js
+++ b/src/pages/shoppingListsPage/__tests__/createGameFromLink.test.js
@@ -85,8 +85,8 @@ describe('Creating a new game from the link', () => {
       const form = await screen.findByTestId('game-form')
 
       // Fill out and submit the form
-      const nameInput = await within(form).findByPlaceholderText('Name')
-      const descInput = await within(form).findByPlaceholderText('Description')
+      const nameInput = within(form).getByPlaceholderText('Name')
+      const descInput = within(form).getByPlaceholderText('Description')
 
       fireEvent.change(nameInput, { target: { value: 'Distinctive Name' } })
       fireEvent.change(descInput, { target: { value: 'New description' } })
@@ -97,7 +97,7 @@ describe('Creating a new game from the link', () => {
 
       // The input of the games dropdown component should be updated so the
       // active game is the newly created game
-      const dropdownComponent = await screen.findByTestId('games-dropdown')
+      const dropdownComponent = screen.getByTestId('games-dropdown')
       await waitFor(() => expect(within(dropdownComponent).queryByDisplayValue('Distinctive Name')).toBeVisible())
 
       // The message that the game has no shopping lists should be visible
@@ -150,8 +150,8 @@ describe('Creating a new game from the link', () => {
       const form = await screen.findByTestId('game-form')
 
       // Fill out and submit the form
-      const nameInput = await within(form).findByPlaceholderText('Name')
-      const descInput = await within(form).findByPlaceholderText('Description')
+      const nameInput = within(form).getByPlaceholderText('Name')
+      const descInput = within(form).getByPlaceholderText('Description')
 
       fireEvent.change(nameInput, { target: { value: 'Distinctive Name' } })
       fireEvent.change(descInput, { target: { value: 'New description' } })
@@ -162,7 +162,7 @@ describe('Creating a new game from the link', () => {
 
       // The input of the games dropdown component should not be updated since
       // there are still no games
-      const dropdownComponent = await screen.findByTestId('games-dropdown')
+      const dropdownComponent = screen.getByTestId('games-dropdown')
       await waitFor(() => expect(within(dropdownComponent).queryByPlaceholderText(/no games available/i)).toBeVisible())
 
       // The message that the user needs a game should be visible
@@ -212,8 +212,8 @@ describe('Creating a new game from the link', () => {
       const form = await screen.findByTestId('game-form')
 
       // Fill out and submit the form
-      const nameInput = await within(form).findByPlaceholderText('Name')
-      const descInput = await within(form).findByPlaceholderText('Description')
+      const nameInput = within(form).getByPlaceholderText('Name')
+      const descInput = within(form).getByPlaceholderText('Description')
 
       fireEvent.change(nameInput, { target: { value: 'Distinctive Name' } })
       fireEvent.change(descInput, { target: { value: 'New description' } })
@@ -260,8 +260,8 @@ describe('Creating a new game from the link', () => {
       const form = await screen.findByTestId('game-form')
 
       // Fill out and submit the form
-      const nameInput = await within(form).findByPlaceholderText('Name')
-      const descInput = await within(form).findByPlaceholderText('Description')
+      const nameInput = within(form).getByPlaceholderText('Name')
+      const descInput = within(form).getByPlaceholderText('Description')
 
       fireEvent.change(nameInput, { target: { value: 'Distinctive Name' } })
       fireEvent.change(descInput, { target: { value: 'New description' } })
@@ -272,7 +272,7 @@ describe('Creating a new game from the link', () => {
 
       // The input of the games dropdown component should still be empty
       // since no game was created
-      const dropdownComponent = await screen.findByTestId('games-dropdown')
+      const dropdownComponent = screen.getByTestId('games-dropdown')
       await waitFor(() => expect(within(dropdownComponent).queryByPlaceholderText(/no games available/i)).toBeVisible())
 
       // The message that the user needs a game to use the shopping lists

--- a/src/pages/shoppingListsPage/__tests__/createList.test.js
+++ b/src/pages/shoppingListsPage/__tests__/createList.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { waitFor, screen, fireEvent } from '@testing-library/react'
+import { within } from '@testing-library/dom'
 import { cleanCookies } from 'universal-cookie/lib/utils'
 import { Cookies, CookiesProvider } from 'react-cookie'
 import { renderWithRouter } from '../../../setupTests'
@@ -86,8 +87,8 @@ describe('Creating a shopping list', () => {
 
       // Find the shopping list create form
       const form = await screen.findByTestId('shopping-list-create-form')
-      const input = await screen.findByLabelText('Title')
-      const button = await screen.findByText('Create')
+      const input = within(form).getByLabelText('Title')
+      const button = within(form).getByText('Create')
 
       fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
       fireEvent.submit(form)
@@ -96,15 +97,15 @@ describe('Creating a shopping list', () => {
       await waitFor(() => expect(screen.queryByText('Proudspire Manor')).toBeVisible())
 
       // The aggregate list should be visible on the page
-      await waitFor(() => expect(screen.queryByText('All Items')).toBeVisible())
+      expect(screen.queryByText('All Items')).toBeVisible()
 
       // A flash success message should be visible on the page
       await waitFor(() => expect(screen.queryByText(/success/i)).toBeVisible())
 
       // The create form should be cleared and still be enabled
       await waitFor(() => expect(input).not.toBeDisabled())
-      await waitFor(() => expect(button).not.toBeDisabled())
-      await waitFor(() => expect(input.value).toEqual(''))
+      expect(button).not.toBeDisabled()
+      expect(input.value).toEqual('')
     })
   })
 
@@ -144,8 +145,8 @@ describe('Creating a shopping list', () => {
 
       // Find the shopping list create form
       const form = await screen.findByTestId('shopping-list-create-form')
-      const input = await screen.findByLabelText('Title')
-      const button = await screen.findByText('Create')
+      const input = within(form).getByLabelText('Title')
+      const button = within(form).getByText('Create')
 
       fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
       fireEvent.submit(form)
@@ -155,8 +156,8 @@ describe('Creating a shopping list', () => {
 
       // The input form should be cleared and not disabled
       await waitFor(() => expect(input).not.toBeDisabled())
-      await waitFor(() => expect(button).not.toBeDisabled())
-      await waitFor(() => expect(input.value).toEqual(''))
+      expect(button).not.toBeDisabled()
+      expect(input.value).toEqual('')
     })
   })
 
@@ -187,8 +188,8 @@ describe('Creating a shopping list', () => {
 
       // Find the shopping list create form
       const form = await screen.findByTestId('shopping-list-create-form')
-      const input = await screen.findByLabelText('Title')
-      const button = await screen.findByText('Create')
+      const input = within(form).getByLabelText('Title')
+      const button = within(form).getByText('Create')
 
       fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
       fireEvent.submit(form)
@@ -198,8 +199,8 @@ describe('Creating a shopping list', () => {
 
       // The input form should not be cleared or disabled
       await waitFor(() => expect(input).not.toBeDisabled())
-      await waitFor(() => expect(button).not.toBeDisabled())
-      await waitFor(() => expect(input.value).toEqual(''))
+      expect(button).not.toBeDisabled()
+      expect(input.value).toEqual('')
     })
   })
 
@@ -233,8 +234,8 @@ describe('Creating a shopping list', () => {
 
       // Find the shopping list create form
       const form = await screen.findByTestId('shopping-list-create-form')
-      const input = await screen.findByLabelText('Title')
-      const button = await screen.findByText('Create')
+      const input = within(form).getByLabelText('Title')
+      const button = within(form).getByText('Create')
 
       fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
       fireEvent.submit(form)
@@ -247,8 +248,8 @@ describe('Creating a shopping list', () => {
 
       // The form should not be cleared or disabled
       await waitFor(() => expect(input).not.toBeDisabled())
-      await waitFor(() => expect(button).not.toBeDisabled())
-      await waitFor(() => expect(input.value).toEqual('Proudspire Manor'))
+      expect(button).not.toBeDisabled()
+      expect(input.value).toEqual('Proudspire Manor')
     })
   })
 
@@ -282,8 +283,8 @@ describe('Creating a shopping list', () => {
 
       // Find the shopping list create form
       const form = await screen.findByTestId('shopping-list-create-form')
-      const input = await screen.findByLabelText('Title')
-      const button = await screen.findByText('Create')
+      const input = within(form).getByLabelText('Title')
+      const button = within(form).getByText('Create')
 
       fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
       fireEvent.submit(form)
@@ -296,8 +297,8 @@ describe('Creating a shopping list', () => {
 
       // The form should not be cleared or disabled
       await waitFor(() => expect(input).not.toBeDisabled())
-      await waitFor(() => expect(button).not.toBeDisabled())
-      await waitFor(() => expect(input.value).toEqual(''))
+      expect(button).not.toBeDisabled()
+      expect(input.value).toEqual('')
     })
   })
 
@@ -331,11 +332,10 @@ describe('Creating a shopping list', () => {
 
       // Find the shopping list create form
       const form = await screen.findByTestId('shopping-list-create-form')
-      const input = await screen.findByLabelText('Title')
+      const input = within(form).getByLabelText('Title')
 
       fireEvent.change(input, { target: { value: 'Proudspire Manor' } })
       fireEvent.submit(form)
-
 
       await waitFor(() => expect(history.location.pathname).toEqual('/login'))
     })

--- a/src/pages/shoppingListsPage/__tests__/destroyList.test.js
+++ b/src/pages/shoppingListsPage/__tests__/destroyList.test.js
@@ -90,7 +90,7 @@ describe('Destroying a shopping list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = await within(listEl).findByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
 
       fireEvent.click(deleteIcon)
 
@@ -105,7 +105,7 @@ describe('Destroying a shopping list', () => {
       // There should be a flash message indicating that the list and its aggregate list
       // have both been destroyed
       await waitFor(() => expect(screen.queryByText(/shopping list has been deleted/i)).toBeVisible())
-      await waitFor(() => expect(screen.queryByText(/"All Items" list has been deleted/i)).toBeVisible())
+      expect(screen.queryByText(/"All Items" list has been deleted/i)).toBeVisible()
     })
   })
 
@@ -155,7 +155,7 @@ describe('Destroying a shopping list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = await within(listEl).findByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
 
       fireEvent.click(deleteIcon)
 
@@ -219,13 +219,13 @@ describe('Destroying a shopping list', () => {
       // Find the regular list and the all-items list by first locating their
       // title elements and then finding the containers
       const listTitle = await screen.findByText('Lakeview Manor')
-      const allItemsTitle = await screen.findByText('All Items')
+      const allItemsTitle = screen.getByText('All Items')
 
       const listEl = listTitle.closest('.root')
       const allItemsEl = allItemsTitle.closest('.root')
 
       // Get the destroy icon for the regular list and click it
-      const deleteIcon = await within(listEl).findByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
 
       fireEvent.click(deleteIcon)
 
@@ -236,7 +236,7 @@ describe('Destroying a shopping list', () => {
       await waitFor(() => expect(listEl).not.toBeInTheDocument())
 
       // The aggregate list should still be visible on the page
-      await waitFor(() => expect(allItemsEl).toBeVisible())
+      expect(allItemsEl).toBeVisible()
 
       // There should be a flash message indicating the list was deleted
       await waitFor(() => expect(screen.queryByText(/shopping list has been deleted/i)).toBeVisible())
@@ -250,7 +250,7 @@ describe('Destroying a shopping list', () => {
       const listItemEl = listItemTitle.closest('.root')
 
       await waitFor(() => expect(within(listItemEl).queryByText('2')).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listItemEl).queryByText('1')).toBeVisible())
+      expect(within(listItemEl).queryByText('1')).toBeVisible()
     })
   })
 
@@ -285,12 +285,10 @@ describe('Destroying a shopping list', () => {
     it("doesn't remove the list and displays an error message", async () => {
       component = renderComponentWithMockCookies(games[0].id)
 
-      component = renderComponentWithMockCookies(games[0].id)
-
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = await within(listEl).findByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
 
       fireEvent.click(deleteIcon)
 
@@ -343,7 +341,7 @@ describe('Destroying a shopping list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = await within(listEl).findByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
 
       fireEvent.click(deleteIcon)
 
@@ -396,7 +394,7 @@ describe('Destroying a shopping list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = await within(listEl).findByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
 
       fireEvent.click(deleteIcon)
 
@@ -428,12 +426,10 @@ describe('Destroying a shopping list', () => {
     it("doesn't remove the list and displays a message", async () => {
       component = renderComponentWithMockCookies(games[0].id)
 
-      component = renderComponentWithMockCookies(games[0].id)
-
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = await within(listEl).findByTestId('delete-shopping-list')
+      const deleteIcon =within(listEl).getByTestId('delete-shopping-list')
 
       fireEvent.click(deleteIcon)
 

--- a/src/pages/shoppingListsPage/__tests__/displayLists.test.js
+++ b/src/pages/shoppingListsPage/__tests__/displayLists.test.js
@@ -108,14 +108,14 @@ describe('Displaying the shopping lists page', () => {
 
         // games[0]'s shopping lists should be visible on the page
         await waitFor(() => expect(screen.queryByText('All Items')).toBeVisible())
-        await waitFor(() => expect(screen.queryByText('Lakeview Manor')).toBeVisible())
-        await waitFor(() => expect(screen.queryByText('Heljarchen Hall')).toBeVisible())
-        await waitFor(() => expect(screen.queryByText('Breezehome')).toBeVisible())
+        expect(screen.queryByText('Lakeview Manor')).toBeVisible()
+        expect(screen.queryByText('Heljarchen Hall')).toBeVisible()
+        expect(screen.queryByText('Breezehome')).toBeVisible()
 
         // games[1]'s shopping lists should not be visible
-        await waitFor(() => expect(screen.queryByText('Windstad Manor')).not.toBeInTheDocument())
-        await waitFor(() => expect(screen.queryByText('Hjerim')).not.toBeInTheDocument())
-        await waitFor(() => expect(screen.queryByText(/no shopping lists/i)).not.toBeInTheDocument())
+        expect(screen.queryByText('Windstad Manor')).not.toBeInTheDocument()
+        expect(screen.queryByText('Hjerim')).not.toBeInTheDocument()
+        expect(screen.queryByText(/no shopping lists/i)).not.toBeInTheDocument()
       })
 
       describe('toggling a shopping list', () => {
@@ -126,9 +126,9 @@ describe('Displaying the shopping lists page', () => {
           // returns a promise, so I had to use waitFor ... getByText instead.
           const lakeviewManorList = await waitFor(() => screen.getByText('Lakeview Manor').closest('.root'))
 
-          await waitFor(() => expect(within(lakeviewManorList).queryByText(/add item to list/i)).not.toBeVisible())
-          await waitFor(() => expect(within(lakeviewManorList).queryByText(/ebony sword/i)).not.toBeVisible())
-          await waitFor(() => expect(within(lakeviewManorList).queryByText(/ingredients with "frenzy" property/i)).not.toBeVisible())
+          expect(within(lakeviewManorList).getByText(/add item to list/i)).not.toBeVisible()
+          expect(within(lakeviewManorList).getByText(/ebony sword/i)).not.toBeVisible()
+          expect(within(lakeviewManorList).getByText(/ingredients with "frenzy" property/i)).not.toBeVisible()
         })
 
         it('displays the list item descriptions but not notes', async () => {
@@ -140,8 +140,8 @@ describe('Displaying the shopping lists page', () => {
           fireEvent.click(lakeviewManor)
 
           await waitFor(() => expect(within(lakeviewManorList).queryByText(/add item to list/i)).toBeVisible())
-          await waitFor(() => expect(within(lakeviewManorList).queryByText(/ebony sword/i)).toBeVisible())
-          await waitFor(() => expect(within(lakeviewManorList).queryByText(/ingredients with "frenzy" property/i)).toBeVisible())
+          expect(within(lakeviewManorList).getByText(/ebony sword/i)).toBeVisible()
+          expect(within(lakeviewManorList).getByText(/ingredients with "frenzy" property/i)).toBeVisible()
         })
 
         it('collapses again when clicked a second time', async () => {
@@ -150,12 +150,13 @@ describe('Displaying the shopping lists page', () => {
           const lakeviewManor = await screen.findByText(/lakeview manor/i)
           const lakeviewManorList = lakeviewManor.closest('.root')
 
+          // Toggle the list items twice by clicking the list title twice
           fireEvent.click(lakeviewManor)
           fireEvent.click(lakeviewManor)
 
           await waitFor(() => expect(within(lakeviewManorList).queryByText(/add item to list/i)).not.toBeVisible())
-          await waitFor(() => expect(within(lakeviewManorList).queryByText(/ebony sword/i)).not.toBeVisible())
-          await waitFor(() => expect(within(lakeviewManorList).queryByText(/ingredients with "frenzy" property/i)).not.toBeVisible())
+          expect(within(lakeviewManorList).getByText(/ebony sword/i)).not.toBeVisible()
+          expect(within(lakeviewManorList).getByText(/ingredients with "frenzy" property/i)).not.toBeVisible()
         })
 
         describe('toggling a list item', () => {
@@ -165,10 +166,14 @@ describe('Displaying the shopping lists page', () => {
             const lakeviewManor = await screen.findByText('Lakeview Manor')
             const lakeviewManorList = lakeviewManor.closest('.root')
 
+            // Toggle the list items by clicking the list title
             fireEvent.click(lakeviewManor)
 
-            await waitFor(() => expect(within(lakeviewManorList).queryByText(/notes 1/i)).not.toBeVisible())
-            await waitFor(() => expect(within(lakeviewManorList).queryByText(/no details available/i)).not.toBeVisible())
+            // The list item titles should be visible but not the notes
+            await waitFor(() => expect(within(lakeviewManorList).queryByText(/ebony sword/i)).toBeVisible())
+            expect(within(lakeviewManorList).getByText(/ingredients with "frenzy" property/i)).toBeVisible()
+            expect(within(lakeviewManorList).getByText(/notes 1/i)).not.toBeVisible()
+            expect(within(lakeviewManorList).getByText(/no details available/i)).not.toBeVisible()
           })
 
           it('expands one item when you click on it', async () => {
@@ -188,7 +193,7 @@ describe('Displaying the shopping lists page', () => {
             await waitFor(() => expect(within(ebonySwordItem).queryByText('notes 1')).toBeVisible())
 
             // Notes for the other item should not be visible
-            await waitFor(() => expect(within(lakeviewManorList).queryByText(/no details available/i)).not.toBeVisible())
+            expect(within(lakeviewManorList).queryByText(/no details available/i)).not.toBeVisible()
           })
 
           it('collapses the item when you click it again', async () => {
@@ -237,14 +242,14 @@ describe('Displaying the shopping lists page', () => {
 
         // The lists belonging to game 1 should be visible
         await waitFor(() => expect(screen.queryByText('All Items')).toBeVisible())
-        await waitFor(() => expect(screen.queryByText('Windstad Manor')).toBeVisible())
-        await waitFor(() => expect(screen.queryByText('Hjerim')).toBeVisible())
+        expect(screen.getByText('Windstad Manor')).toBeVisible()
+        expect(screen.getByText('Hjerim')).toBeVisible()
 
         // The lists belonging to game 0 should be absent
-        await waitFor(() => expect(screen.queryByText('Lakeview Manor')).not.toBeInTheDocument())
-        await waitFor(() => expect(screen.queryByText('Heljarchen Hall')).not.toBeInTheDocument())
-        await waitFor(() => expect(screen.queryByText('Breezehome')).not.toBeInTheDocument())
-        await waitFor(() => expect(screen.queryByText(/no shopping lists/i)).not.toBeInTheDocument())
+        expect(screen.queryByText('Lakeview Manor')).not.toBeInTheDocument()
+        expect(screen.queryByText('Heljarchen Hall')).not.toBeInTheDocument()
+        expect(screen.queryByText('Breezehome')).not.toBeInTheDocument()
+        expect(screen.queryByText(/no shopping lists/i)).not.toBeInTheDocument()
       })
     })
 
@@ -269,7 +274,7 @@ describe('Displaying the shopping lists page', () => {
         const { history } = component = renderComponentWithMockCookies(cookies)
 
         const dropdownComponent = await screen.findByTestId('games-dropdown')
-        const dropdownTrigger = await screen.findByTestId('games-dropdown-trigger')
+        const dropdownTrigger = screen.getByTestId('games-dropdown-trigger')
 
         fireEvent.click(dropdownTrigger)
 
@@ -282,15 +287,15 @@ describe('Displaying the shopping lists page', () => {
         await waitFor(() => expect(history.location.search).toEqual(`?game_id=${games[1].id}`))
 
         // The lists belonging to game 1 should be visible
-        await waitFor(() => expect(screen.queryByText('All Items')).toBeVisible())
-        await waitFor(() => expect(screen.queryByText('Windstad Manor')).toBeVisible())
-        await waitFor(() => expect(screen.queryByText('Hjerim')).toBeVisible())
+        await waitFor(() => expect(screen.getByText('Windstad Manor')).toBeVisible())
+        expect(screen.getByText('Hjerim')).toBeVisible()
+        expect(screen.getByText('All Items')).toBeVisible()
 
         // The lists belonging to game 0 should be absent
-        await waitFor(() => expect(screen.queryByText('Lakeview Manor')).not.toBeInTheDocument())
-        await waitFor(() => expect(screen.queryByText('Heljarchen Hall')).not.toBeInTheDocument())
-        await waitFor(() => expect(screen.queryByText('Breezehome')).not.toBeInTheDocument())
-        await waitFor(() => expect(screen.queryByText(/no shopping lists/i)).not.toBeInTheDocument())
+        expect(screen.queryByText('Lakeview Manor')).not.toBeInTheDocument()
+        expect(screen.queryByText('Heljarchen Hall')).not.toBeInTheDocument()
+        expect(screen.queryByText('Breezehome')).not.toBeInTheDocument()
+        expect(screen.queryByText(/no shopping lists/i)).not.toBeInTheDocument()
       })
     })
 
@@ -331,8 +336,6 @@ describe('Displaying the shopping lists page', () => {
 
       it('tells the user they need to create a game', async () => {
         const { history } = component = renderComponentWithMockCookies(cookies, null, emptyGames)
-
-        const link = await screen.findByText(/you need a game/i)
 
         await waitFor(() => expect(screen.queryByText(/you need a game/i)).toBeVisible())
       })

--- a/src/pages/shoppingListsPage/__tests__/editList.test.js
+++ b/src/pages/shoppingListsPage/__tests__/editList.test.js
@@ -73,13 +73,13 @@ describe('Editing a shopping list', () => {
       // Find the shopping list component for this list and click its edit icon
       const listTitleEl = await screen.findByText(list.title)
       const listEl = listTitleEl.closest('.root')
-      const editIcon = await within(listEl).findByTestId('edit-shopping-list')
+      const editIcon = within(listEl).getByTestId('edit-shopping-list')
 
       fireEvent.click(editIcon)
 
       // It should not display the list items when you click on it
       await waitFor(() => expect(within(listEl).queryByText(list.list_items[0].description)).not.toBeVisible())
-      await waitFor(() => expect(within(listEl).queryByText(list.list_items[1].description)).not.toBeVisible())
+      expect(within(listEl).queryByText(list.list_items[1].description)).not.toBeVisible()
 
       // There should be an input with the list's title as its `value`
       await waitFor(() => expect(within(listEl).queryByDisplayValue(list.title)).toBeVisible())
@@ -94,7 +94,7 @@ describe('Editing a shopping list', () => {
       // Find the shopping list component for this list and click its edit icon
       const listTitleEl = await screen.findByText(list.title)
       const listEl = listTitleEl.closest('.root')
-      const editIcon = await within(listEl).findByTestId('edit-shopping-list')
+      const editIcon = within(listEl).getByTestId('edit-shopping-list')
 
       fireEvent.click(editIcon)
 
@@ -105,7 +105,7 @@ describe('Editing a shopping list', () => {
 
       // The input should no longer be present, but the list should
       await waitFor(() => expect(input).not.toBeInTheDocument())
-      await waitFor(() => expect(listEl).toBeInTheDocument())
+      expect(listEl).toBeInTheDocument()
     })
   })
 
@@ -141,7 +141,7 @@ describe('Editing a shopping list', () => {
       // Find the shopping list component for this list and click its edit icon
       const listTitleEl = await screen.findByText(list.title)
       const listEl = listTitleEl.closest('.root')
-      const editIcon = await within(listEl).findByTestId('edit-shopping-list')
+      const editIcon = within(listEl).getByTestId('edit-shopping-list')
 
       fireEvent.click(editIcon)
 
@@ -155,7 +155,7 @@ describe('Editing a shopping list', () => {
 
       // The input should be hidden and the new title should be visible
       await waitFor(() => expect(input).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listEl).queryByText('Honeyside')).toBeVisible())
+      expect(listEl).toHaveTextContent(/Honeyside/)
     })
   })
 
@@ -184,7 +184,7 @@ describe('Editing a shopping list', () => {
       // Find the shopping list component for this list and click its edit icon
       const listTitleEl = await screen.findByText(list.title)
       const listEl = listTitleEl.closest('.root')
-      const editIcon = await within(listEl).findByTestId('edit-shopping-list')
+      const editIcon = within(listEl).getByTestId('edit-shopping-list')
 
       fireEvent.click(editIcon)
 
@@ -196,8 +196,13 @@ describe('Editing a shopping list', () => {
       fireEvent.change(input, { target: { value: 'Honeyside' } })
       fireEvent.submit(form)
 
+      // The input should be hidden
       await waitFor(() => expect(input).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listEl).queryByText('Honeyside')).not.toBeInTheDocument())
+
+      // The title should not be updated
+      await waitFor(() => expect(listEl).not.toHaveTextContent(/Honeyside/))
+
+      // The flash error message should be visible
       await waitFor(() => expect(screen.queryByText(/could not be found/i)).toBeVisible())
     })
   })
@@ -231,7 +236,7 @@ describe('Editing a shopping list', () => {
       // Find the shopping list component for this list and click its edit icon
       const listTitleEl = await screen.findByText(list.title)
       const listEl = listTitleEl.closest('.root')
-      const editIcon = await within(listEl).findByTestId('edit-shopping-list')
+      const editIcon = within(listEl).getByTestId('edit-shopping-list')
 
       fireEvent.click(editIcon)
 
@@ -247,7 +252,7 @@ describe('Editing a shopping list', () => {
       await waitFor(() => expect(input).not.toBeInTheDocument())
 
       // The title should not be updated in the view
-      await waitFor(() => expect(within(listEl).queryByText(gameLists[2].title)).not.toBeInTheDocument())
+      await waitFor(() => expect(listEl).not.toHaveTextContent(gameLists[2].title))
 
       // There should be a flash error message with the validation errors
       await waitFor(() => expect(screen.queryByText(/title must be unique per game/i)).toBeVisible())
@@ -283,7 +288,7 @@ describe('Editing a shopping list', () => {
       // Find the shopping list component for this list and click its edit icon
       const listTitleEl = await screen.findByText(list.title)
       const listEl = listTitleEl.closest('.root')
-      const editIcon = await within(listEl).findByTestId('edit-shopping-list')
+      const editIcon = within(listEl).getByTestId('edit-shopping-list')
 
       fireEvent.click(editIcon)
 
@@ -299,7 +304,7 @@ describe('Editing a shopping list', () => {
       await waitFor(() => expect(input).not.toBeInTheDocument())
 
       // The title should not be updated
-      await waitFor(() => expect(within(listEl).queryByText('This will not work')).not.toBeInTheDocument())
+      await waitFor(() => expect(listEl).not.toHaveTextContent(/Honeyside/))
 
       // There should be a flash error message explaining what happened
       await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())
@@ -334,7 +339,7 @@ describe('Editing a shopping list', () => {
       // Find the shopping list component for this list and click its edit icon
       const listTitleEl = await screen.findByText(list.title)
       const listEl = listTitleEl.closest('.root')
-      const editIcon = await within(listEl).findByTestId('edit-shopping-list')
+      const editIcon = within(listEl).getByTestId('edit-shopping-list')
 
       fireEvent.click(editIcon)
 

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItem401.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItem401.test.js
@@ -74,8 +74,8 @@ describe('Creating a shopping list item - when the server returns a 404', () => 
     fireEvent.click(formTrigger)
 
     const descriptionInput = await within(listEl).findByPlaceholderText(/description/i)
-    const quantityInput = await within(listEl).findByDisplayValue('1')
-    const notesInput = await within(listEl).findByPlaceholderText(/notes/i)
+    const quantityInput = within(listEl).getByDisplayValue('1')
+    const notesInput = within(listEl).getByPlaceholderText(/notes/i)
 
     const form = descriptionInput.closest('form')
 

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItem404.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItem404.test.js
@@ -71,8 +71,8 @@ describe('Creating a shopping list item - when the server returns a 404', () => 
     fireEvent.click(formTrigger)
 
     const descriptionInput = await within(listEl).findByPlaceholderText(/description/i)
-    const quantityInput = await within(listEl).findByDisplayValue('1')
-    const notesInput = await within(listEl).findByPlaceholderText(/notes/i)
+    const quantityInput = within(listEl).getByDisplayValue('1')
+    const notesInput = within(listEl).getByPlaceholderText(/notes/i)
 
     const form = descriptionInput.closest('form')
 
@@ -87,7 +87,7 @@ describe('Creating a shopping list item - when the server returns a 404', () => 
     await waitFor(() => expect(form).not.toBeVisible())
 
     // The item should not be added to the list
-    expect(within(listEl).queryByText('Dwarven metal ingots')).not.toBeInTheDocument()
+    expect(listEl).not.toHaveTextContent(/Dwarven metal ingots/)
 
     //  There should be an error message
     await waitFor(() => expect(screen.queryByText(/couldn't find/i)).toBeVisible())

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItem422.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItem422.test.js
@@ -74,8 +74,8 @@ describe('Creating a shopping list item when the attributes are invalid', () => 
     fireEvent.click(formTrigger)
 
     const descriptionInput = await within(listEl).findByPlaceholderText(/description/i)
-    const quantityInput = await within(listEl).findByDisplayValue('1')
-    const notesInput = await within(listEl).findByPlaceholderText(/notes/i)
+    const quantityInput = within(listEl).getByDisplayValue('1')
+    const notesInput = within(listEl).getByPlaceholderText(/notes/i)
 
     const form = descriptionInput.closest('form')
 
@@ -87,10 +87,10 @@ describe('Creating a shopping list item when the attributes are invalid', () => 
     fireEvent.submit(form)
 
     // Form should not be hidden in this case
-    expect(form).toBeVisible()
+    await waitFor(() => expect(form).toBeVisible())
 
     // The item should not be added to the list
-    expect(within(listEl).queryByText('Dwarven metal ingots')).not.toBeInTheDocument()
+    expect(listEl).not.toHaveTextContent(/Dwarven metal ingots/)
 
     //  There should be an error message
     await waitFor(() => expect(screen.queryByText(/quantity must be greater than zero/i)).toBeVisible())

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItem500.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItem500.test.js
@@ -74,8 +74,8 @@ describe('Creating a shopping list item when the server returns a 404', () => {
     fireEvent.click(formTrigger)
 
     const descriptionInput = await within(listEl).findByPlaceholderText(/description/i)
-    const quantityInput = await within(listEl).findByDisplayValue('1')
-    const notesInput = await within(listEl).findByPlaceholderText(/notes/i)
+    const quantityInput = within(listEl).getByDisplayValue('1')
+    const notesInput = within(listEl).getByPlaceholderText(/notes/i)
 
     const form = descriptionInput.closest('form')
 
@@ -90,7 +90,7 @@ describe('Creating a shopping list item when the server returns a 404', () => {
     await waitFor(() => expect(form).not.toBeVisible())
 
     // The item should not be added to the list
-    expect(within(listEl).queryByText('Dwarven metal ingots')).not.toBeInTheDocument()
+    expect(listEl).not.toHaveTextContent(/Dwarven metal ingots/)
 
     //  There should be an error message
     await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItemHappyPath.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/createListItemHappyPath.test.js
@@ -92,8 +92,8 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(formTrigger)
 
       const descriptionInput = await within(listEl).findByPlaceholderText(/description/i)
-      const quantityInput = await within(listEl).findByDisplayValue('1')
-      const notesInput = await within(listEl).findByPlaceholderText(/notes/i)
+      const quantityInput = within(listEl).getByDisplayValue('1')
+      const notesInput = within(listEl).getByPlaceholderText(/notes/i)
 
       const form = descriptionInput.closest('form')
 
@@ -116,7 +116,7 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(itemTitle)
 
       await waitFor(() => expect(within(itemElOnRegList).queryByText('10')).toBeVisible())
-      await waitFor(() => expect(within(itemElOnRegList).queryByText('To make bolts with')).toBeVisible())
+      expect(within(itemElOnRegList).getByText('To make bolts with')).toBeVisible()
 
       // The item should be added to the all items list - expand the list to see
       const allItemsTitle = await screen.findByText(/all items/i)
@@ -133,7 +133,7 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(itemTitleOnAggList)
 
       await waitFor(() => expect(within(itemElOnAggList).queryByText('10')).toBeVisible())
-      await waitFor(() => expect(within(itemElOnAggList).queryByText('To make bolts with')).toBeVisible())
+      expect(itemElOnAggList).toHaveTextContent(/To make bolts with/)
 
       // There should be a flash message visible
       await waitFor(() => expect(screen.queryByText(/has been created/i)).toBeVisible())
@@ -191,8 +191,8 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(formTrigger)
 
       const descriptionInput = await within(listEl).findByPlaceholderText(/description/i)
-      const quantityInput = await within(listEl).findByDisplayValue('1')
-      const notesInput = await within(listEl).findByPlaceholderText(/notes/i)
+      const quantityInput = within(listEl).getByDisplayValue('1')
+      const notesInput = within(listEl).getByPlaceholderText(/notes/i)
 
       const form = descriptionInput.closest('form')
 
@@ -215,7 +215,7 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(itemTitle)
 
       await waitFor(() => expect(within(itemElOnRegList).queryByText('5')).toBeVisible())
-      await waitFor(() => expect(within(itemElOnRegList).queryByText('To make poison with')).toBeVisible())
+      expect(itemElOnRegList).toHaveTextContent(/To make poison with/)
 
       // The item should be updated on the all items list but should not appear
       // on the list twice.
@@ -232,7 +232,7 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(item)
 
       await waitFor(() => expect(within(itemEl).queryByText('9')).toBeVisible())
-      await waitFor(() => expect(within(itemEl).queryByText('To make poison with')).toBeVisible())
+      expect(itemEl).toHaveTextContent(/To make poison with/)
     })
   })
 
@@ -286,8 +286,8 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(formTrigger)
 
       const descriptionInput = await within(listEl).findByPlaceholderText(/description/i)
-      const quantityInput = await within(listEl).findByDisplayValue('1')
-      const notesInput = await within(listEl).findByPlaceholderText(/notes/i)
+      const quantityInput = within(listEl).getByDisplayValue('1')
+      const notesInput = within(listEl).getByPlaceholderText(/notes/i)
 
       const form = descriptionInput.closest('form')
 
@@ -311,7 +311,7 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(itemTitle)
 
       await waitFor(() => expect(within(itemElOnRegList).queryByText('3')).toBeVisible())
-      await waitFor(() => expect(within(itemElOnRegList).queryByText('notes 1 -- notes 3')).toBeVisible())
+      expect(itemElOnRegList).toHaveTextContent('notes 1 -- notes 3')
 
       // The item should be on the all items list only once as well.
       const allItemsTitle = await screen.findByText(/all items/i)
@@ -328,7 +328,7 @@ describe('Creating a shopping list item - happy path', () => {
       fireEvent.click(itemTitleOnAggList)
 
       await waitFor(() => expect(within(itemElOnAggList).queryByText('4')).toBeVisible())
-      await waitFor(() => expect(within(itemElOnAggList).queryByText('notes 1 -- notes 2 -- notes 3')).toBeVisible())
+      expect(itemElOnAggList).toHaveTextContent('notes 1 -- notes 2 -- notes 3')
 
       // There should be a flash message indicating the item was combined with another item
       await waitFor(() => expect(screen.queryByText(/combined with another item/i)).toBeVisible())

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/decrementListItemHappyPath.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/decrementListItemHappyPath.test.js
@@ -86,7 +86,7 @@ describe('Decrementing a shopping list item - happy path', () => {
     // property'. Its initial quantity is 4.
     const itemDescEl = await within(listEl).findByText(/frenzy/i)
     const itemEl = itemDescEl.closest('.root')
-    const decrementer = await within(itemEl).findByTestId('decrementer')
+    const decrementer = within(itemEl).getByTestId('decrementer')
 
     fireEvent.click(decrementer)
 
@@ -95,7 +95,7 @@ describe('Decrementing a shopping list item - happy path', () => {
 
     // Now find the corresponding item on the aggregate list. Start by
     // finding the list itself.
-    const aggListTitleEl = await screen.findByText('All Items')
+    const aggListTitleEl = screen.getByText('All Items')
     const aggListEl = aggListTitleEl.closest('.root')
 
     // Expand the list

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/destroyShoppingListItem.test.js
@@ -67,7 +67,7 @@ describe('Destroying a shopping list item', () => {
       const regItemDescEl = await within(listEl).findByText(/frenzy/i)
       const regItemEl = regItemDescEl.closest('.root')
 
-      const destroyIcon = await within(regItemEl).findByTestId('destroy-item')
+      const destroyIcon = within(regItemEl).getByTestId('destroy-item')
 
       // Click on the destroy icon
       fireEvent.click(destroyIcon)
@@ -79,14 +79,14 @@ describe('Destroying a shopping list item', () => {
       await waitFor(() => expect(regItemEl).toBeVisible())
 
       // Find the aggregate list
-      const aggListTitle = await screen.findByText('All Items')
+      const aggListTitle = screen.getByText('All Items')
       const aggListEl = aggListTitle.closest('.root')
 
       // Expand the aggregate list to show the list items
       fireEvent.click(aggListTitle)
 
       // The list item should still be on the aggregate list too
-      await waitFor(() => expect(within(aggListEl).queryByText(/frenzy/i)).toBeVisible())
+      await waitFor(() => expect(aggListEl).toHaveTextContent(/frenzy/i))
 
       // There should be a flash info message
       await waitFor(() => expect(screen.queryByText(/not deleted/i)).toBeVisible())
@@ -131,7 +131,7 @@ describe('Destroying a shopping list item', () => {
       const regItemDescEl = await within(listEl).findByText(/frenzy/i)
       const regItemEl = regItemDescEl.closest('.root')
 
-      const destroyIcon = await within(regItemEl).findByTestId('destroy-item')
+      const destroyIcon = within(regItemEl).getByTestId('destroy-item')
 
       // Click on the destroy icon
       fireEvent.click(destroyIcon)
@@ -140,8 +140,7 @@ describe('Destroying a shopping list item', () => {
       await waitFor(() => expect(confirm).toHaveBeenCalled())
 
       // The item should be removed from the regular list
-      await waitForElementToBeRemoved(regItemEl)
-      expect(regItemEl).not.toBeInTheDocument()
+      await waitFor(() => expect(regItemEl).not.toBeInTheDocument())
 
       // Find the aggregate list
       const aggListTitle = await screen.findByText('All Items')
@@ -151,7 +150,7 @@ describe('Destroying a shopping list item', () => {
       fireEvent.click(aggListTitle)
 
       // The list item should not be on the aggregate list either
-      await waitFor(() => expect(within(aggListEl).queryByText(/frenzy/i)).not.toBeInTheDocument())
+      await waitFor(() => expect(aggListEl).not.toHaveTextContent(/frenzy/i))
     })
   })
 
@@ -200,7 +199,7 @@ describe('Destroying a shopping list item', () => {
       const regItemDescEl = await within(listEl).findByText('Ebony sword')
       const regItemEl = regItemDescEl.closest('.root')
 
-      const destroyIcon = await within(regItemEl).findByTestId('destroy-item')
+      const destroyIcon = within(regItemEl).getByTestId('destroy-item')
 
       // Click on the destroy icon
       fireEvent.click(destroyIcon)
@@ -209,18 +208,17 @@ describe('Destroying a shopping list item', () => {
       await waitFor(() => expect(confirm).toHaveBeenCalled())
 
       // The item should be removed from the regular list
-      await waitForElementToBeRemoved(regItemEl)
-      expect(regItemEl).not.toBeInTheDocument()
+      await waitFor(() => expect(regItemEl).not.toBeInTheDocument())
 
       // Find the aggregate list
-      const aggListTitle = await screen.findByText('All Items')
+      const aggListTitle = screen.getByText('All Items')
       const aggListEl = aggListTitle.closest('.root')
 
       // Expand the aggregate list to show the list items
       fireEvent.click(aggListTitle)
 
       // The list item should still be on the aggregate list
-      await waitFor(() => expect(within(aggListEl).queryByText('Ebony sword')).toBeVisible())
+      await waitFor(() => expect(aggListEl).toHaveTextContent(/Ebony sword/))
     })
   })
 
@@ -261,7 +259,7 @@ describe('Destroying a shopping list item', () => {
       // property'
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const destroyIcon = await within(itemEl).findByTestId('destroy-item')
+      const destroyIcon = within(itemEl).getByTestId('destroy-item')
 
       fireEvent.click(destroyIcon)
 
@@ -304,7 +302,7 @@ describe('Destroying a shopping list item', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const destroy = await within(itemEl).findByTestId('destroy-item')
+      const destroy = within(itemEl).getByTestId('destroy-item')
 
       fireEvent.click(destroy)
 
@@ -312,14 +310,14 @@ describe('Destroying a shopping list item', () => {
       await waitFor(() => expect(listEl).toBeVisible())
 
       // Find the aggregate list
-      const aggListTitle = await screen.findByText('All Items')
+      const aggListTitle = screen.getByText('All Items')
       const aggListEl = aggListTitle.closest('.root')
 
       // Expand the aggregate list to show the list items
       fireEvent.click(aggListTitle)
 
       // The list item should still be on the aggregate list too
-      await waitFor(() => expect(within(aggListEl).queryByText(/frenzy/i)).toBeVisible())
+      await waitFor(() => expect(aggListEl).toHaveTextContent(/frenzy/i))
 
       // There should be a flash message visible
       await waitFor(() => expect(screen.queryByText(/couldn't find/i)).toBeVisible())
@@ -363,7 +361,7 @@ describe('Destroying a shopping list item', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const destroy = await within(itemEl).findByTestId('destroy-item')
+      const destroy = within(itemEl).getByTestId('destroy-item')
 
       fireEvent.click(destroy)
 
@@ -371,14 +369,14 @@ describe('Destroying a shopping list item', () => {
       await waitFor(() => expect(listEl).toBeVisible())
 
       // Find the aggregate list
-      const aggListTitle = await screen.findByText('All Items')
+      const aggListTitle = screen.getByText('All Items')
       const aggListEl = aggListTitle.closest('.root')
 
       // Expand the aggregate list to show the list items
       fireEvent.click(aggListTitle)
 
       // The list item should still be on the aggregate list too
-      await waitFor(() => expect(within(aggListEl).queryByText(/frenzy/i)).toBeVisible())
+      await waitFor(() => expect(aggListEl).toHaveTextContent(/frenzy/i))
 
       // There should be a flash error message
       await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/incrementDecrementErrorCases.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/incrementDecrementErrorCases.test.js
@@ -71,7 +71,7 @@ describe('Incrementing a shopping list item - error cases', () => {
         // property'. Its initial quantity is 4.
         const itemDescEl = await within(listEl).findByText(/frenzy/i)
         const itemEl = itemDescEl.closest('.root')
-        const incrementer = await within(itemEl).findByTestId('incrementer')
+        const incrementer = within(itemEl).getByTestId('incrementer')
 
         fireEvent.click(incrementer)
 
@@ -94,7 +94,7 @@ describe('Incrementing a shopping list item - error cases', () => {
         // property'. Its initial quantity is 4.
         const itemDescEl = await within(listEl).findByText(/frenzy/i)
         const itemEl = itemDescEl.closest('.root')
-        const decrementer = await within(itemEl).findByTestId('decrementer')
+        const decrementer = within(itemEl).getByTestId('decrementer')
 
         fireEvent.click(decrementer)
 
@@ -131,7 +131,7 @@ describe('Incrementing a shopping list item - error cases', () => {
         // property'. Its initial quantity is 4.
         const itemDescEl = await within(listEl).findByText(/frenzy/i)
         const itemEl = itemDescEl.closest('.root')
-        const incrementer = await within(itemEl).findByTestId('incrementer')
+        const incrementer = within(itemEl).getByTestId('incrementer')
 
         fireEvent.click(incrementer)
 
@@ -140,7 +140,7 @@ describe('Incrementing a shopping list item - error cases', () => {
 
         // Now find the corresponding item on the aggregate list. Start by
         // finding the list itself.
-        const aggListTitleEl = await screen.findByText('All Items')
+        const aggListTitleEl = screen.getByText('All Items')
         const aggListEl = aggListTitleEl.closest('.root')
 
         // Expand the list
@@ -173,7 +173,7 @@ describe('Incrementing a shopping list item - error cases', () => {
         // property'. Its initial quantity is 4.
         const itemDescEl = await within(listEl).findByText(/frenzy/i)
         const itemEl = itemDescEl.closest('.root')
-        const decrementer = await within(itemEl).findByTestId('decrementer')
+        const decrementer = within(itemEl).getByTestId('decrementer')
 
         fireEvent.click(decrementer)
 
@@ -182,7 +182,7 @@ describe('Incrementing a shopping list item - error cases', () => {
 
         // Now find the corresponding item on the aggregate list. Start by
         // finding the list itself.
-        const aggListTitleEl = await screen.findByText('All Items')
+        const aggListTitleEl = screen.getByText('All Items')
         const aggListEl = aggListTitleEl.closest('.root')
 
         // Expand the list
@@ -232,7 +232,7 @@ describe('Incrementing a shopping list item - error cases', () => {
         // property'. Its initial quantity is 4.
         const itemDescEl = await within(listEl).findByText(/frenzy/i)
         const itemEl = itemDescEl.closest('.root')
-        const incrementer = await within(itemEl).findByTestId('incrementer')
+        const incrementer = within(itemEl).getByTestId('incrementer')
 
         fireEvent.click(incrementer)
 
@@ -241,7 +241,7 @@ describe('Incrementing a shopping list item - error cases', () => {
 
         // Now find the corresponding item on the aggregate list. Start by
         // finding the list itself.
-        const aggListTitleEl = await screen.findByText('All Items')
+        const aggListTitleEl = screen.getByText('All Items')
         const aggListEl = aggListTitleEl.closest('.root')
 
         // Expand the list
@@ -274,7 +274,7 @@ describe('Incrementing a shopping list item - error cases', () => {
         // property'. Its initial quantity is 4.
         const itemDescEl = await within(listEl).findByText(/frenzy/i)
         const itemEl = itemDescEl.closest('.root')
-        const decrementer = await within(itemEl).findByTestId('decrementer')
+        const decrementer = within(itemEl).getByTestId('decrementer')
 
         fireEvent.click(decrementer)
 
@@ -283,7 +283,7 @@ describe('Incrementing a shopping list item - error cases', () => {
 
         // Now find the corresponding item on the aggregate list. Start by
         // finding the list itself.
-        const aggListTitleEl = await screen.findByText('All Items')
+        const aggListTitleEl = screen.getByText('All Items')
         const aggListEl = aggListTitleEl.closest('.root')
 
         // Expand the list

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/incrementListItemHappyPath.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/incrementListItemHappyPath.test.js
@@ -86,7 +86,7 @@ describe('Incrementing a shopping list item - happy path', () => {
     // property'. Its initial quantity is 4.
     const itemDescEl = await within(listEl).findByText(/frenzy/i)
     const itemEl = itemDescEl.closest('.root')
-    const incrementer = await within(itemEl).findByTestId('incrementer')
+    const incrementer = within(itemEl).getByTestId('incrementer')
 
     fireEvent.click(incrementer)
 
@@ -95,7 +95,7 @@ describe('Incrementing a shopping list item - happy path', () => {
 
     // Now find the corresponding item on the aggregate list. Start by
     // finding the list itself.
-    const aggListTitleEl = await screen.findByText('All Items')
+    const aggListTitleEl = screen.getByText('All Items')
     const aggListEl = aggListTitleEl.closest('.root')
 
     // Expand the list

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/updateShoppingListItemErrorCases.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/updateShoppingListItemErrorCases.test.js
@@ -70,17 +70,17 @@ describe('Updating a shopping list item - error cases', () => {
       // property'. Its initial quantity is 4.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const editIcon = within(itemEl).getByTestId('edit-item')
 
       fireEvent.click(editIcon)
 
       // It should display the list item edit form
       const form = await screen.findByTestId('shopping-list-item-form')
-      await waitFor(() => expect(form).toBeVisible())
+      expect(form).toBeVisible()
 
       // Now find the form fields and fill out the form. This item has no notes
       // so we find the notes field by placeholder text instead.
-      const notesField = await within(form).findByPlaceholderText('This item has no notes')
+      const notesField = within(form).getByPlaceholderText('This item has no notes')
 
       // Fill out the form field. We'll change just the notes value for the
       // sake of simplicity.
@@ -120,17 +120,17 @@ describe('Updating a shopping list item - error cases', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const editIcon = within(itemEl).getByTestId('edit-item')
 
       fireEvent.click(editIcon)
 
       // It should display the list item edit form
       const form = await screen.findByTestId('shopping-list-item-form')
-      await waitFor(() => expect(form).toBeVisible())
+      expect(form).toBeVisible()
 
       // Now find the form fields and fill out the form. This item has no notes
       // so we find the notes field by placeholder text instead.
-      const notesField = await within(form).findByPlaceholderText('This item has no notes')
+      const notesField = within(form).getByPlaceholderText('This item has no notes')
 
       // Fill out the form field. We'll change just the notes value for the
       // sake of simplicity.
@@ -140,12 +140,11 @@ describe('Updating a shopping list item - error cases', () => {
       fireEvent.submit(form)
 
       // The form should be hidden 
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
+      await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // Now we need to find the item on the regular list and the
       // aggregate list.
-      const aggListTitleEl = await screen.findByText('All Items')
+      const aggListTitleEl = screen.getByText('All Items')
       const aggListEl = aggListTitleEl.closest('.root')
 
       // Expand the list so the item is visible
@@ -161,8 +160,8 @@ describe('Updating a shopping list item - error cases', () => {
 
       // Now we need to check that the aggregate list item and regular list
       // item are updated.
-      await waitFor(() => expect(within(aggListItemEl).queryByText('This item has notes now')).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listEl).queryByText('This item has notes now')).not.toBeInTheDocument())
+      await waitFor(() => expect(aggListItemEl).not.toHaveTextContent('This item has notes now'))
+      expect(listEl).not.toHaveTextContent('This item has notes now')
 
       // Finally, it should display the flash message.
       await waitFor(() => expect(screen.queryByText(/couldn't find/i)).toBeVisible())
@@ -198,16 +197,16 @@ describe('Updating a shopping list item - error cases', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const editIcon = within(itemEl).getByTestId('edit-item')
 
       fireEvent.click(editIcon)
 
       // It should display the list item edit form
       const form = await screen.findByTestId('shopping-list-item-form')
-      await waitFor(() => expect(form).toBeVisible())
+      expect(form).toBeVisible()
 
       // Now find the form fields and fill out the form.
-      const quantityField = await within(form).findByDisplayValue('4')
+      const quantityField = within(form).getByDisplayValue('4')
 
       // In this case we'll set it to an invalid value
       fireEvent.change(quantityField, { target: { value: '-6' } })
@@ -216,12 +215,11 @@ describe('Updating a shopping list item - error cases', () => {
       fireEvent.submit(form)
 
       // The form should be hidden 
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
+      await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // Now we need to find the item on the regular list and the
       // aggregate list.
-      const aggListTitleEl = await screen.findByText('All Items')
+      const aggListTitleEl = screen.getByText('All Items')
       const aggListEl = aggListTitleEl.closest('.root')
 
       // Expand the list so the item is visible
@@ -238,7 +236,7 @@ describe('Updating a shopping list item - error cases', () => {
       // Now we need to check that the aggregate list item and regular list
       // item are updated.
       await waitFor(() => expect(within(aggListItemEl).queryByText('-6')).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listEl).queryByText('-6')).not.toBeInTheDocument())
+      expect(within(listEl).queryByText('-6')).not.toBeInTheDocument()
 
       // Finally, it should display the flash message.
       await waitFor(() => expect(screen.queryByText(/Quantity must be greater than zero/)).toBeVisible())
@@ -274,16 +272,16 @@ describe('Updating a shopping list item - error cases', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const editIcon = within(itemEl).getByTestId('edit-item')
 
       fireEvent.click(editIcon)
 
       // It should display the list item edit form
       const form = await screen.findByTestId('shopping-list-item-form')
-      await waitFor(() => expect(form).toBeVisible())
+      expect(form).toBeVisible()
 
       // Now find the form fields and fill out the form.
-      const quantityField = await within(form).findByDisplayValue('4')
+      const quantityField = within(form).getByDisplayValue('4')
 
       // In this case we'll set it to an invalid value
       fireEvent.change(quantityField, { target: { value: '-6' } })
@@ -292,12 +290,11 @@ describe('Updating a shopping list item - error cases', () => {
       fireEvent.submit(form)
 
       // The form should be hidden 
-      await waitForElementToBeRemoved(form)
-      expect(form).not.toBeInTheDocument()
+      await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // Now we need to find the item on the regular list and the
       // aggregate list.
-      const aggListTitleEl = await screen.findByText('All Items')
+      const aggListTitleEl = screen.getByText('All Items')
       const aggListEl = aggListTitleEl.closest('.root')
 
       // Expand the list so the item is visible
@@ -314,7 +311,7 @@ describe('Updating a shopping list item - error cases', () => {
       // Now we need to check that the aggregate list item and regular list
       // item are updated.
       await waitFor(() => expect(within(aggListItemEl).queryByText('-6')).not.toBeInTheDocument())
-      await waitFor(() => expect(within(listEl).queryByText('-6')).not.toBeInTheDocument())
+      expect(within(listEl).queryByText('-6')).not.toBeInTheDocument()
 
       // Finally, it should display the flash message.
       await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())

--- a/src/pages/shoppingListsPage/__tests__/shoppingListItems/updateShoppingListItemHappyPath.test.js
+++ b/src/pages/shoppingListsPage/__tests__/shoppingListItems/updateShoppingListItemHappyPath.test.js
@@ -88,17 +88,17 @@ describe('Updating a shopping list item - happy path', () => {
     // property'. Its initial quantity is 4 and it has no notes.
     const itemDescEl = await within(listEl).findByText(/frenzy/i)
     const itemEl = itemDescEl.closest('.root')
-    const editIcon = await within(itemEl).findByTestId('edit-item')
+    const editIcon = within(itemEl).getByTestId('edit-item')
 
     fireEvent.click(editIcon)
 
     // It should display the list item edit form
     const form = await screen.findByTestId('shopping-list-item-form')
-    await waitFor(() => expect(form).toBeVisible())
+    expect(form).toBeVisible()
 
     // Now find the form fields and fill out the form. This item has no notes
     // so we find the notes field by placeholder text instead.
-    const notesField = await within(form).findByPlaceholderText('This item has no notes')
+    const notesField = within(form).getByPlaceholderText('This item has no notes')
 
     // Fill out the form field. We'll change just the notes value for the
     // sake of simplicity.
@@ -108,12 +108,11 @@ describe('Updating a shopping list item - happy path', () => {
     fireEvent.submit(form)
 
     // The form should be hidden 
-    await waitForElementToBeRemoved(form)
-    expect(form).not.toBeInTheDocument()
+    await waitFor(() => expect(form).not.toBeInTheDocument())
 
     // Now we need to find the item on the regular list and the
     // aggregate list.
-    const aggListTitleEl = await screen.findByText('All Items')
+    const aggListTitleEl = screen.getByText('All Items')
     const aggListEl = aggListTitleEl.closest('.root')
 
     // Expand the list so the item is visible
@@ -129,8 +128,8 @@ describe('Updating a shopping list item - happy path', () => {
 
     // Now we need to check that the aggregate list item and regular list
     // item are updated.
-    await waitFor(() => expect(within(aggListItemEl).queryByText('This item has notes now')).toBeVisible())
-    await waitFor(() => expect(within(listEl).queryByText('This item has notes now')).toBeVisible())
+    await waitFor(() => expect(aggListItemEl).toHaveTextContent('This item has notes now'))
+    expect(listEl).toHaveTextContent('This item has notes now')
 
     // Finally, it should display the flash message.
     await waitFor(() => expect(screen.queryByText(/updated/i)).toBeVisible())
@@ -150,13 +149,13 @@ describe('Updating a shopping list item - happy path', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const editIcon = within(itemEl).getByTestId('edit-item')
 
       fireEvent.click(editIcon)
 
       // It should display the modal and form
       const modal = await screen.findByRole('dialog')
-      const form = await within(modal).findByTestId('shopping-list-item-form')
+      const form = within(modal).getByTestId('shopping-list-item-form')
       expect(form).toBeVisible()
 
       // Now press the escape key to hide the modal
@@ -181,13 +180,13 @@ describe('Updating a shopping list item - happy path', () => {
       // property'. Its initial quantity is 4 and it has no notes.
       const itemDescEl = await within(listEl).findByText(/frenzy/i)
       const itemEl = itemDescEl.closest('.root')
-      const editIcon = await within(itemEl).findByTestId('edit-item')
+      const editIcon = within(itemEl).getByTestId('edit-item')
 
       fireEvent.click(editIcon)
 
       // It should display the modal and form
       const modal = await screen.findByRole('dialog')
-      const form = await within(modal).findByTestId('shopping-list-item-form')
+      const form = within(modal).getByTestId('shopping-list-item-form')
       expect(form).toBeVisible()
 
       // Now click on the modal element, outside the form, to hide it


### PR DESCRIPTION
## Context

[**Clean up unneeded async stuff in Jest**](https://trello.com/c/UIpH4k1W/125-clean-up-unneeded-async-stuff-in-jest)

Our Jest tests have a few more `await`s that they need. There are a number of points where we use `await` to wait for elements that will already be present by the time it gets to that line. These are unneeded and may slow down tests.

## Changes

* Remove unnecessary `await`s from Jest tests
