### PR TITLE
Update handlers to accept new API response bodies

### DIFF
--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -334,20 +334,23 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
         if (!mountedRef.current) return
 
         if (status === 200 || status === 201) {
-          const [aggregateListItem, regularListItem] = json
-
           // Have to create an actual new object or the state change won't cause useEffect
           // hooks to run.
           const newLists = [...shoppingLists]
-          const aggregateList = shoppingLists[0]
-          const regularList = shoppingLists.find(list => list.id === listId)
-          const regularListPosition = shoppingLists.indexOf(regularList)
 
-          const newAggregateList = addOrUpdateListItem(aggregateList, aggregateListItem)
-          const newRegularList = addOrUpdateListItem(regularList, regularListItem)
+          // The JSON object returned from this endpoint is the array of all items
+          // that have been updated while handling this request. Because changing the
+          // `unit_weight` of a shopping list item can cause items other than the
+          // list item edited and the aggregate list item to be updated, it's not
+          // possible to know for sure how many items the array will contain. It will
+          // be at least two though.
+          for (let i = 0; i < json.length; i++) {
+            const list = shoppingLists.find(list => list.id === json[i].list_id)
+            const listPosition = shoppingLists.indexOf(list)
+            const newList = addOrUpdateListItem(list, json[i])
 
-          newLists[0] = newAggregateList
-          newLists[regularListPosition] = newRegularList
+            newLists[listPosition] = newList
+          }
 
           setShoppingLists(newLists)
 
@@ -411,18 +414,14 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
         if (!mountedRef.current) return
 
         if (status === 200) {
-          const [aggregateListItem, regularListItem] = json
-
           let newShoppingLists = [...shoppingLists]
 
-          const regularList = shoppingLists.find(list => list.id === regularListItem.list_id)
-          const regularListPosition = shoppingLists.indexOf(regularList)
-
-          const newAggregateList = addOrUpdateListItem(shoppingLists[0], aggregateListItem)
-          const newRegularList = addOrUpdateListItem(regularList, regularListItem)
-
-          newShoppingLists[0] = newAggregateList
-          newShoppingLists[regularListPosition] = newRegularList
+          for (let i = 0; i < json.length; i++) {
+            const list = shoppingLists.find(list => list.id === json[i].list_id)
+            const newList = addOrUpdateListItem(list, json[i])
+            const listPosition = shoppingLists.indexOf(list)
+            newShoppingLists[listPosition] = newList
+          }
 
           setShoppingLists(newShoppingLists)
 


### PR DESCRIPTION
## Context

[**Incorporate unit_weight logic into Aggregatable and Listable concerns**](https://trello.com/c/GSVOgowG/156-incorporate-unitweight-logic-into-aggregatable-and-listable-concerns)

In danascheider/skyrim_inventory_management#63, the `ShoppingListItem` model has been updated to handle logic around the `unit_weight` column. Now, shopping lists update all items for one game with a matching description when `unit_weight` is changed to a non-`nil` value for one of them. In other words, if there are existing list items called "Ebony Sword" with a unit weight of 14 and I create a new one or update an existing one to have a weight of 16, the weight of all of them will be changed to 16.

The API response has also been updated accordingly. Now, instead of returning a two-element array with the aggregate list item and the newly created/updated regular list item, `POST /shopping_lists/:list_id/shopping_list_items` and `PATCH /shopping_list_items/:id` will return an array of all items updated while handling the request. The list items are not guaranteed to be in any particular order.

The front end is not yet equipped to handle the new response bodies. It assumes that an aggregate list item will be returned as the first element and the regular list item as the second. We need to handle responses that include more than two list items.

## Changes

* Use loop to find shopping lists and update list items when list items are created or updated

## Considerations

The shopping list items that are returned now are a superset of those that were returned before. For that reason, logic that handles the superset will not break anything when there are only two items returned. For that reason, existing tests didn't need to be updated.

I wanted to add tests to make sure that the superset was handled correctly. However, since the UI doesn't yet display unit weight, there was no realistic test case I could implement that would demonstrate that things were working as desired.

## Manual Test Cases

These changes don't change UI appearance or application behaviour.
