### PR TITLE
Enable user to delete inventory list from UI

### DIFF
--- a/docs/contexts/inventory-lists-context.md
+++ b/docs/contexts/inventory-lists-context.md
@@ -35,9 +35,20 @@ A function that takes the `listId` of the list to be updated, a new `title`, and
 The `callbacks` object can contain the following callbacks:
 
 * `onSuccess`: called after a 200-range response has been handled successfully
-* `onNotFound`: called when the game the user requests to create a list for is not found or does not belong to the authenticated user
+* `onNotFound`: called when the list the user wants to update is not found or does not belong to the authenticated user
 * `onUnauthorized`: called when the request returns a 401 response
 * `onUnprocessableEntity`: called when the title the user submits is invalid or not unique
+* `onInternalServerError`: called when the server returns a 500-range response or there is an unexpected error while handling the response
+
+### `performInventoryListDestroy`
+
+A function that takes the `listId` of the list to be destroyed and a `callbacks` object and destroys the requested list, calling the appropriate callback when the request has completed.
+
+The `callbacks` object can contain the following callbacks:
+
+* `onSuccess`: called after a 200-range response has been handled successfully (possible responses are 200 and 204)
+* `onNotFound`: called when the list requested is not found or does not belong to the authenticated user
+* `onUnauthorized`: called when the request returns a 401 response
 * `onInternalServerError`: called when the server returns a 500-range response or there is an unexpected error while handling the response
 
 ## Testing Components in Storybook

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -26,7 +26,7 @@ const isValid = str => (
 const InventoryList = ({ canEdit = true, listId, title }) => {
   const DELETE_CONFIRMATION = `Are you sure you want to delete the list "${title}"? You will also lose any list items on the list. This action cannot be undone.`
 
-  const { setFlashVisible } = useAppContext()
+  const { setFlashAttributes, setFlashVisible } = useAppContext()
   const {
     inventoryLists,
     performInventoryListUpdate,
@@ -115,7 +115,16 @@ const InventoryList = ({ canEdit = true, listId, title }) => {
         mountedRef.current = false
       }
 
-      performInventoryListDestroy(listId, { onSuccess })
+      const onError = setFlashVisible(true)
+
+      performInventoryListDestroy(listId, { onSuccess, onNotFound: onError, onInternalServerError: onError })
+    } else {
+      setFlashAttributes({
+        type: 'info',
+        message: 'Your list was not deleted.'
+      })
+
+      setFlashVisible(true)
     }
   }
 

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -152,12 +152,12 @@ const InventoryList = ({ canEdit = true, listId, title }) => {
         <div className={styles.trigger} ref={slideTriggerRef} onClick={toggleListItems}>
           {canEdit &&
           <span className={styles.editIcons} ref={iconsRef}>
-            <div className={styles.icon} ref={deleteTriggerRef} onClick={deleteList} data-testid='delete-inventory-list'>
+            <button className={styles.icon} ref={deleteTriggerRef} onClick={deleteList} data-testid='delete-inventory-list'>
               <FontAwesomeIcon className={styles.fa} icon={faTimes} />
-            </div>
-            <div className={styles.icon} ref={triggerRef} data-testid='edit-inventory-list'>
+            </button>
+            <button className={styles.icon} ref={triggerRef} data-testid='edit-inventory-list'>
               <FontAwesomeIcon className={styles.fa} icon={faEdit} />
-            </div>
+            </button>
           </span>}
           {canEdit && isComponentVisible ?
             <ListEditForm
@@ -173,6 +173,7 @@ const InventoryList = ({ canEdit = true, listId, title }) => {
       <SlideToggle toggleEvent={toggleEvent} collapsed>
         {({ setCollapsibleElement }) => (
           <div className={styles.collapsible} ref={setCollapsibleElement}>
+            {!canEdit && listItems.length === 0 && <div className={styles.emptyList}>This game has no inventory list items.</div>}
             {listItems && listItems.length > 0 && listItems.map(({ id, description, quantity, notes, unit_weight }) => {
               const itemKey = `${title.toLowerCase().replace(' ', '-')}-${id}`
 

--- a/src/components/inventoryList/inventoryList.module.css
+++ b/src/components/inventoryList/inventoryList.module.css
@@ -10,7 +10,8 @@
 .root:hover,
 .root:hover .trigger,
 .root:hover .form input,
-.root:hover .form button {
+.root:hover .form button,
+.root:hover .icon {
   background-color: var(--hover-color);
 }
 
@@ -38,6 +39,11 @@
 
 .icon {
   display: inline;
+  border: none;
+  padding: 0;
+  background-color: var(--scheme-color);
+  cursor: pointer;
+  color: var(--text-color-primary);
 }
 
 .icon:first-of-type {
@@ -69,9 +75,20 @@
   border: 1px solid var(--border-color);
 }
 
+.emptyList {
+  font-size: 1.025rem;
+  background-color: var(--scheme-color-lighter);
+  color: var(--text-color-secondary);
+  padding: 32px 24px;
+}
+
 @media (min-width: 769px) {
   .root {
     width: 80%;
+  }
+
+  .emptyList {
+    font-size: 1.125rem;
   }
 }
 

--- a/src/components/inventoryList/inventoryList.module.css
+++ b/src/components/inventoryList/inventoryList.module.css
@@ -40,6 +40,10 @@
   display: inline;
 }
 
+.icon:first-of-type {
+  margin-right: 8px;
+}
+
 .editIcons {
   margin: auto 0;
 }

--- a/src/components/inventoryList/inventoryList.stories.js
+++ b/src/components/inventoryList/inventoryList.stories.js
@@ -84,7 +84,7 @@ export const Editable = () => (
   <AppProvider overrideValue={{ token, setShouldRedirectTo: () => null }}>
     <GamesProvider overrideValue={{ games, gameLoadingState: 'done' }}>
       <ColorProvider colorScheme={AQUA}>
-        <InventoryListsProvider overrideValue={{ inventoryLists }}>
+        <InventoryListsProvider overrideValue={{ inventoryLists, performInventoryListDestroy: () => {} }}>
           <InventoryList
             listId={2}
             title='My List 1'
@@ -161,7 +161,7 @@ export const EmptyList = () => (
   <AppProvider overrideValue={{ token, setShouldRedirectTo: () => null }}>
     <GamesProvider overrideValue={{ games, gameLoadingState: 'done' }}>
       <ColorProvider colorScheme={AQUA}>
-        <InventoryListsProvider overrideValue={{ inventoryLists: emptyInventoryLists }}>
+        <InventoryListsProvider overrideValue={{ inventoryLists: emptyInventoryLists, performInventoryListDestroy: () => {} }}>
           <InventoryList
             listId={2}
             title='My List 2'

--- a/src/components/inventoryPageContent/storyData.js
+++ b/src/components/inventoryPageContent/storyData.js
@@ -1,0 +1,20 @@
+export const inventoryListUpdateData = {
+  user_id: 24,
+  aggregate: false,
+  list_items: [
+    {
+      id: 1,
+      list_id: 1,
+      description: 'Ebony sword',
+      quantity: 1,
+      notes: 'notes 1'
+    },
+    {
+      id: 3,
+      list_id: 1,
+      description: 'Ingredients with "Frenzy" property',
+      quantity: 4,
+      notes: null
+    }
+  ]
+}

--- a/src/components/shoppingList/shoppingList.js
+++ b/src/components/shoppingList/shoppingList.js
@@ -154,12 +154,12 @@ const ShoppingList = ({ canEdit = true, listId, title }) => {
         <div className={styles.trigger} ref={slideTriggerRef} onClick={toggleListItems}>
           {canEdit &&
           <span className={styles.editIcons} ref={iconsRef}>
-            <div className={styles.icon} ref={deleteTriggerRef} onClick={deleteList} data-testid='delete-shopping-list'>
+            <button className={styles.icon} ref={deleteTriggerRef} onClick={deleteList} data-testid='delete-shopping-list'>
               <FontAwesomeIcon className={styles.fa} icon={faTimes} />
-            </div>
-            <div className={styles.icon} ref={triggerRef} data-testid='edit-shopping-list'>
+            </button>
+            <button className={styles.icon} ref={triggerRef} data-testid='edit-shopping-list'>
               <FontAwesomeIcon className={styles.fa} icon={faEdit} />
-            </div>
+            </button>
           </span>}
           {canEdit && isComponentVisible ?
             <ListEditForm
@@ -175,7 +175,7 @@ const ShoppingList = ({ canEdit = true, listId, title }) => {
       <SlideToggle toggleEvent={toggleEvent} collapsed>
         {({ setCollapsibleElement }) => (
           <div className={styles.collapsible} ref={setCollapsibleElement}>
-            {!canEdit && listItems.length === 0 && <div className={styles.emptyList}>You have no shopping list items.</div>}
+            {!canEdit && listItems.length === 0 && <div className={styles.emptyList}>This game has no shopping list items.</div>}
             {canEdit && <ShoppingListItemCreateForm listId={listId} />}
             {listItems && listItems.length > 0 && listItems.map(({ id, description, quantity, notes, unit_weight }) => {
               const itemKey = `${title.toLowerCase().replace(' ', '-')}-${id}`

--- a/src/components/shoppingList/shoppingList.module.css
+++ b/src/components/shoppingList/shoppingList.module.css
@@ -10,7 +10,8 @@
 .root:hover,
 .root:hover .trigger,
 .root:hover .form input,
-.root:hover .form button {
+.root:hover .form button,
+.root:hover .icon {
   background-color: var(--hover-color);
 }
 
@@ -29,6 +30,10 @@
 
 .icon {
   display: inline;
+  border: none;
+  background-color: var(--scheme-color);
+  padding: 0;
+  cursor: pointer;
 }
 
 .editIcons {
@@ -55,6 +60,7 @@
   margin-left: 8px;
   font-size: 1rem;
   display: inline-block;
+  color: var(--text-color-primary);
 }
 
 .fa:hover {

--- a/src/contexts/shoppingListsContext.js
+++ b/src/contexts/shoppingListsContext.js
@@ -290,7 +290,7 @@ const ShoppingListsProvider = ({ children, overrideValue = {} }) => {
 
           onSuccess && onSuccess()
         } else {
-          const message = json.errors ? `Error ${status} when deleting shopping list: ${json.errors}` : `Unknown error ${status} when deleting shopping list`
+          const message = json.errors ? `Error ${status} when deleting shopping list: ${json.errors}` : `Unknown error ${status} when deleting shopping list ${listId}`
           throw new Error(message)
         }
       })

--- a/src/pages/inventoryPage/__tests__/destroyList.test.js
+++ b/src/pages/inventoryPage/__tests__/destroyList.test.js
@@ -278,7 +278,6 @@ describe('Destroying a inventory list', () => {
     })
 
     afterEach(() => confirm.mockRestore())
-
     afterAll(() => server.close())
 
     it("doesn't remove the list and displays an error message", async () => {
@@ -287,7 +286,7 @@ describe('Destroying a inventory list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-inventory-list')
 
       fireEvent.click(deleteIcon)
 
@@ -340,7 +339,7 @@ describe('Destroying a inventory list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-inventory-list')
 
       fireEvent.click(deleteIcon)
 
@@ -393,7 +392,7 @@ describe('Destroying a inventory list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-inventory-list')
 
       fireEvent.click(deleteIcon)
 
@@ -406,7 +405,7 @@ describe('Destroying a inventory list', () => {
     })
   })
 
-  describe('cancelling deletion of a shopping list', () => {
+  describe('cancelling deletion of an inventory list', () => {
     let confirm
     
     const server = setupServer.apply(null, sharedHandlers)
@@ -419,7 +418,6 @@ describe('Destroying a inventory list', () => {
     })
 
     afterEach(() => confirm.mockRestore())
-
     afterAll(() => server.close())
     
     it("doesn't remove the list and displays a message", async () => {
@@ -428,7 +426,7 @@ describe('Destroying a inventory list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon =within(listEl).getByTestId('delete-shopping-list')
+      const deleteIcon =within(listEl).getByTestId('delete-inventory-list')
 
       fireEvent.click(deleteIcon)
 

--- a/src/pages/inventoryPage/__tests__/destroyList.test.js
+++ b/src/pages/inventoryPage/__tests__/destroyList.test.js
@@ -1,0 +1,446 @@
+import React from 'react'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import {
+  waitFor,
+  screen,
+  waitForElementToBeRemoved,
+  fireEvent
+} from '@testing-library/react'
+import { within } from '@testing-library/dom'
+import { cleanCookies } from 'universal-cookie/lib/utils'
+import { Cookies, CookiesProvider } from 'react-cookie'
+import { renderWithRouter } from '../../../setupTests'
+import { backendBaseUri } from '../../../utils/config'
+import { AppProvider } from '../../../contexts/appContext'
+import { GamesProvider } from '../../../contexts/gamesContext'
+import { InventoryListsProvider } from '../../../contexts/inventoryListsContext'
+import { profileData, games, allInventoryLists } from '../../../sharedTestData'
+import InventoryPage from './../inventoryPage'
+
+describe('Destroying a inventory list', () => {
+  let component
+
+  const renderComponentWithMockCookies = (gameId = null, allGames = games) => {
+    const route = gameId ? `/dashboard/inventory?game_id=${gameId}` : '/dashboard/inventory'
+
+    const cookies = new Cookies('_sim_google_session="xxxxxx"')
+    cookies.HAS_DOCUMENT_COOKIE = false
+
+    return renderWithRouter(
+      <CookiesProvider cookies={cookies}>
+        <AppProvider overrideValue={{ profileData }}>
+          <GamesProvider overrideValue={{ games: allGames, gameLoadingState: 'done' }} >
+            <InventoryListsProvider>
+              <InventoryPage />
+            </InventoryListsProvider>
+          </GamesProvider>
+        </AppProvider>
+      </CookiesProvider>,
+      { route }
+    )
+  }
+
+  const sharedHandlers = [
+    rest.get(`${backendBaseUri}/games/:gameId/inventory_lists`, (req, res, ctx) => {
+      const gameId = parseInt(req.params.gameId)
+      const lists = allInventoryLists.filter(list => list.game_id === gameId)
+
+      return res(
+        ctx.status(200),
+        ctx.json(lists)
+      )
+    })
+  ]
+
+  beforeEach(() => cleanCookies())
+  afterEach(() => component && component.unmount())
+
+  describe('when there is only one regular list', () => {
+    const handlers = [
+      rest.delete(`${backendBaseUri}/inventory_lists/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(204)
+        )
+      }),
+      ...sharedHandlers
+    ]
+    
+    const server = setupServer.apply(null, handlers)
+
+    let confirm
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+
+      // For these tests, the user will click "OK" each time
+      // they are asked.
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
+    afterAll(() => server.close())
+
+    it('prompts the user and removes the list and aggregate list', async () => {
+      component = renderComponentWithMockCookies(games[0].id)
+
+      // Find the list on the page and locate its destroy icon
+      const listTitle = await screen.findByText('Lakeview Manor')
+      const listEl = listTitle.closest('.root')
+      const deleteIcon = within(listEl).getByTestId('delete-inventory-list')
+
+      fireEvent.click(deleteIcon)
+
+      // The user should be prompted to confirm that they want to destroy the
+      // list
+      expect(confirm).toHaveBeenCalled()
+
+      // Both the list and aggregate list should be removed
+      await waitFor(() => expect(listEl).not.toBeInTheDocument())
+      expect(screen.queryByText('All Items')).not.toBeInTheDocument()
+
+      // There should be a flash message indicating that the list and its aggregate list
+      // have both been destroyed
+      await waitFor(() => expect(screen.queryByText(/inventory list has been deleted/i)).toBeVisible())
+      expect(screen.queryByText(/"All Items" list has been deleted/i)).toBeVisible()
+    })
+  })
+
+  describe('when there are multiple regular lists and no list items', () => {
+    const handlers = [
+      rest.get(`${backendBaseUri}/games/:gameId/inventory_lists`, (req, res, ctx) => {
+        const lists = [
+          { ...allInventoryLists[0], list_items: [] },
+          { ...allInventoryLists[1], list_items: [] },
+          { ...allInventoryLists[2], list_items: [] }
+        ]
+        
+        return res(
+          ctx.status(200),
+          ctx.json(lists)
+        )
+      }),
+      rest.delete(`${backendBaseUri}/inventory_lists/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({ ...allInventoryLists[0], list_items: [] })
+        )
+      })
+    ]
+    
+    const server = setupServer.apply(null, handlers)
+
+    let confirm
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+
+      // For these tests, the user will click "OK" each time
+      // they are asked.
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
+
+    afterAll(() => server.close())
+
+    it('removes the list but not the aggregate list', async () => {
+      component = renderComponentWithMockCookies(games[0].id)
+
+      // Find the list on the page and locate its destroy icon
+      const listTitle = await screen.findByText('Lakeview Manor')
+      const listEl = listTitle.closest('.root')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+
+      fireEvent.click(deleteIcon)
+
+      // The user should be prompted to confirm that they want to destroy the
+      // list
+      expect(confirm).toHaveBeenCalled()
+
+      // The list should be removed
+      await waitFor(() => expect(listEl).not.toBeInTheDocument())
+
+      // The aggregate list should still be visible on the page
+      await waitFor(() => expect(screen.queryByText(/all items/i)).toBeVisible())
+
+      // There should be a flash message indicating the list was deleted
+      await waitFor(() => expect(screen.queryByText(/shopping list has been deleted/i)).toBeVisible())
+    })
+  })
+
+  describe('when there are multiple regular lists with list items', () => {
+    const handlers = [
+      rest.delete(`${backendBaseUri}/inventory_lists/${allInventoryLists[1].id}`, (req, res, ctx) => {
+        const newListItems = [
+          {
+            id: allInventoryLists[0].list_items[0].id,
+            list_id: allInventoryLists[0].id,
+            description: 'Ebony sword',
+            quantity: 1,
+            notes: 'notes 2'
+          }
+        ]
+
+        return res(
+          ctx.status(200),
+          ctx.json({ ...allInventoryLists[0], list_items: newListItems })
+        )
+      }),
+      ...sharedHandlers
+    ]
+    
+    const server = setupServer.apply(null, handlers)
+
+    let confirm
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+
+      // For these tests, the user will click "OK" each time
+      // they are asked.
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
+
+    afterAll(() => server.close())
+
+    it('removes the list and updates the aggregate list items to match the response', async () => {
+      component = renderComponentWithMockCookies(games[0].id)
+
+      // Find the regular list and the all-items list by first locating their
+      // title elements and then finding the containers
+      const listTitle = await screen.findByText('Lakeview Manor')
+      const allItemsTitle = screen.getByText('All Items')
+
+      const listEl = listTitle.closest('.root')
+      const allItemsEl = allItemsTitle.closest('.root')
+
+      // Get the destroy icon for the regular list and click it
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+
+      fireEvent.click(deleteIcon)
+
+      // The user should be asked to confirm they want to delete the list
+      expect(confirm).toHaveBeenCalled()
+
+      // The list should be removed
+      await waitFor(() => expect(listEl).not.toBeInTheDocument())
+
+      // The aggregate list should still be visible on the page
+      expect(allItemsEl).toBeVisible()
+
+      // There should be a flash message indicating the list was deleted
+      await waitFor(() => expect(screen.queryByText(/shopping list has been deleted/i)).toBeVisible())
+
+      // Expand the aggregate list so its list items are visible
+      fireEvent.click(allItemsTitle)
+
+      // Find the relevant list items and check that the quantity has been reduced
+      // from 2 to 1 in accordance with the API response
+      const listItemTitle = await within(allItemsEl).findByText(/ebony sword/i)
+      const listItemEl = listItemTitle.closest('.root')
+
+      await waitFor(() => expect(within(listItemEl).queryByText('2')).not.toBeInTheDocument())
+      expect(within(listItemEl).queryByText('1')).toBeVisible()
+    })
+  })
+
+  describe('when the server returns a 404 error', () => {
+    const handlers = [
+      rest.delete(`${backendBaseUri}/inventory_lists/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(404)
+        )
+      }),
+      ...sharedHandlers
+    ]
+    
+    const server = setupServer.apply(null, handlers)
+
+    let confirm
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+
+      // For these tests, the user will click "OK" each time
+      // they are asked.
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
+
+    afterAll(() => server.close())
+
+    it("doesn't remove the list and displays an error message", async () => {
+      component = renderComponentWithMockCookies(games[0].id)
+
+      // Find the list on the page and locate its destroy icon
+      const listTitle = await screen.findByText('Lakeview Manor')
+      const listEl = listTitle.closest('.root')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+
+      fireEvent.click(deleteIcon)
+
+      // The user should be prompted to confirm that they want to destroy the
+      // list
+      expect(confirm).toHaveBeenCalled()
+
+      // The list should not be removed from the page
+      await waitFor(() => expect(listEl).toBeVisible())
+
+      // There should be a flash error message explaining what happened
+      await waitFor(() => expect(screen.queryByText(/couldn't find/i)).toBeVisible())
+    })
+  })
+
+  describe('when the server returns a 500 error', () => {
+    const handlers = [
+      rest.delete(`${backendBaseUri}/inventory_lists/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(500),
+          ctx.json({ errors: ['Something went horribly wrong'] })
+        )
+      }),
+      ...sharedHandlers
+    ]
+    
+    const server = setupServer.apply(null, handlers)
+
+    let confirm
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+
+      // For these tests, the user will click "OK" each time
+      // they are asked.
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+
+    afterEach(() => confirm.mockRestore())
+
+    afterAll(() => server.close())
+
+    it("doesn't remove the list and displays an error message", async () => {
+      component = renderComponentWithMockCookies(games[0].id)
+
+      component = renderComponentWithMockCookies(games[0].id)
+
+      // Find the list on the page and locate its destroy icon
+      const listTitle = await screen.findByText('Lakeview Manor')
+      const listEl = listTitle.closest('.root')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+
+      fireEvent.click(deleteIcon)
+
+      // The user should be prompted to confirm that they want to destroy the
+      // list
+      expect(confirm).toHaveBeenCalled()
+
+      // The list should not be removed from the page
+      await waitFor(() => expect(listEl).toBeVisible())
+
+      // There should be a flash error message
+      await waitFor(() => expect(screen.queryByText(/something unexpected happened/i)).toBeVisible())
+    })
+  })
+
+  describe('when the server indicates the user has been logged out', () => {
+    const handlers = [
+      rest.delete(`${backendBaseUri}/inventory_lists/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(401),
+          ctx.json({ errors: ['Google OAuth token validation failed'] })
+        )
+      }),
+      ...sharedHandlers
+    ]
+    
+    const server = setupServer.apply(null, handlers)
+
+    let confirm
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+
+      // For these tests, the user will click "OK" each time
+      // they are asked.
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
+    })
+    
+    afterEach(() => confirm.mockRestore())
+
+    afterAll(() => server.close())
+
+    it('redirects the user to the login page', async () => {
+      const { history } = component = renderComponentWithMockCookies(games[0].id)
+
+      component = renderComponentWithMockCookies(games[0].id)
+
+      // Find the list on the page and locate its destroy icon
+      const listTitle = await screen.findByText('Lakeview Manor')
+      const listEl = listTitle.closest('.root')
+      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+
+      fireEvent.click(deleteIcon)
+
+      // The user should be prompted to confirm that they want to destroy the
+      // list
+      expect(confirm).toHaveBeenCalled()
+
+      // The user should be redirected to the login page
+      await waitFor(() => expect(history.location.pathname).toEqual('/login'))
+    })
+  })
+
+  describe('cancelling deletion of a shopping list', () => {
+    let confirm
+    
+    const server = setupServer.apply(null, sharedHandlers)
+
+    beforeAll(() => server.listen())
+
+    beforeEach(() => {
+      server.resetHandlers()
+      confirm = jest.spyOn(window, 'confirm').mockImplementation(() => false)
+    })
+
+    afterEach(() => confirm.mockRestore())
+
+    afterAll(() => server.close())
+    
+    it("doesn't remove the list and displays a message", async () => {
+      component = renderComponentWithMockCookies(games[0].id)
+
+      // Find the list on the page and locate its destroy icon
+      const listTitle = await screen.findByText('Lakeview Manor')
+      const listEl = listTitle.closest('.root')
+      const deleteIcon =within(listEl).getByTestId('delete-shopping-list')
+
+      fireEvent.click(deleteIcon)
+
+      // The user should be prompted to confirm that they want to destroy the
+      // list
+      expect(confirm).toHaveBeenCalled()
+
+      // When the user cancels, the list should not be removed
+      await waitFor(() => expect(listEl).toBeVisible())
+
+      // There should be a flash info message indicating the list was not deleted
+      await waitFor(() => expect(screen.queryByText(/not deleted/i)).toBeVisible())
+    })
+  })
+})

--- a/src/pages/inventoryPage/__tests__/destroyList.test.js
+++ b/src/pages/inventoryPage/__tests__/destroyList.test.js
@@ -154,7 +154,7 @@ describe('Destroying a inventory list', () => {
       // Find the list on the page and locate its destroy icon
       const listTitle = await screen.findByText('Lakeview Manor')
       const listEl = listTitle.closest('.root')
-      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-inventory-list')
 
       fireEvent.click(deleteIcon)
 
@@ -166,10 +166,10 @@ describe('Destroying a inventory list', () => {
       await waitFor(() => expect(listEl).not.toBeInTheDocument())
 
       // The aggregate list should still be visible on the page
-      await waitFor(() => expect(screen.queryByText(/all items/i)).toBeVisible())
+      await waitFor(() => expect(screen.queryByText('All Items')).toBeVisible())
 
       // There should be a flash message indicating the list was deleted
-      await waitFor(() => expect(screen.queryByText(/shopping list has been deleted/i)).toBeVisible())
+      await waitFor(() => expect(screen.queryByText(/inventory list has been deleted/i)).toBeVisible())
     })
   })
 
@@ -224,7 +224,7 @@ describe('Destroying a inventory list', () => {
       const allItemsEl = allItemsTitle.closest('.root')
 
       // Get the destroy icon for the regular list and click it
-      const deleteIcon = within(listEl).getByTestId('delete-shopping-list')
+      const deleteIcon = within(listEl).getByTestId('delete-inventory-list')
 
       fireEvent.click(deleteIcon)
 
@@ -238,7 +238,7 @@ describe('Destroying a inventory list', () => {
       expect(allItemsEl).toBeVisible()
 
       // There should be a flash message indicating the list was deleted
-      await waitFor(() => expect(screen.queryByText(/shopping list has been deleted/i)).toBeVisible())
+      await waitFor(() => expect(screen.queryByText(/inventory list has been deleted/i)).toBeVisible())
 
       // Expand the aggregate list so its list items are visible
       fireEvent.click(allItemsTitle)

--- a/src/pages/inventoryPage/__tests__/destroyList.test.js
+++ b/src/pages/inventoryPage/__tests__/destroyList.test.js
@@ -4,7 +4,6 @@ import { setupServer } from 'msw/node'
 import {
   waitFor,
   screen,
-  waitForElementToBeRemoved,
   fireEvent
 } from '@testing-library/react'
 import { within } from '@testing-library/dom'

--- a/src/pages/inventoryPage/inventoryPage.stories.js
+++ b/src/pages/inventoryPage/inventoryPage.stories.js
@@ -318,7 +318,7 @@ GameNotFoundOnCreate.parameters = {
     }),
     rest.delete(`${backendBaseUri}/inventory_lists/:id`, (req, res, ctx) => {
       return res(
-        ctx.status(400)
+        ctx.status(404)
       )
     })
   ]

--- a/src/pages/shoppingListsPage/__tests__/destroyList.test.js
+++ b/src/pages/shoppingListsPage/__tests__/destroyList.test.js
@@ -4,7 +4,6 @@ import { setupServer } from 'msw/node'
 import {
   waitFor,
   screen,
-  waitForElementToBeRemoved,
   fireEvent
 } from '@testing-library/react'
 import { within } from '@testing-library/dom'

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -340,7 +340,7 @@ export const destroyInventoryList = (token, listId) => {
         if (resp.status === 204) {
           return { status: resp.status, json: null }
         } else {
-          return response.json().then(json => ({ status: resp.status, json }))
+          return resp.json().then(json => ({ status: resp.status, json }))
         }
       })
   )

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -326,3 +326,22 @@ export const updateInventoryList = (token, listId, attrs) => {
       })
   )
 }
+
+// DELETE /inventory_lists/:id
+export const destroyInventoryList = (token, listId) => {
+  const uri = `${backendBaseUri}/inventory_lists/${listId}`
+
+  return(
+    fetch(uri, { method: 'DELETE', headers: authHeader(token) })
+      .then(resp => {
+        if (resp.status === 401) throw new AuthorizationError()
+        if (resp.status === 404) throw new NotFoundError()
+
+        if (resp.status === 204) {
+          return { status: resp.status, json: null }
+        } else {
+          return response.json().then(json => ({ status: resp.status, json }))
+        }
+      })
+  )
+}


### PR DESCRIPTION
## Context

[**Enable user to delete inventory list from the UI**](https://trello.com/c/mZf6pi69/148-enable-user-to-delete-inventory-list-from-ui)

We need to enable users to destroy their (regular, editable) inventory lists through the UI. Aggregate/All Items lists should not be destroyed.

## Changes

* New `destroyInventoryList` function in the `simApi` module to make `DELETE` requests
* New `performInventoryListDestroy` function in the `InventoryListsProvider` to call the `simApi` function and handle the response
* X icon on editable inventory lists enabling them to be destroyed (users are prompted before destroying a list)
* Jest tests for destroy functionality
* Docs update to account for new context function

## Screenshots and GIFs

### All Items (Non-Editable) Inventory List

<img width="776" alt="Screen Shot 2021-08-15 at 4 18 39 pm" src="https://user-images.githubusercontent.com/5115928/129469182-ba2861df-47c1-4ecf-87f0-f15b01eec8c9.png">

### Editable Inventory List

<img width="770" alt="Screen Shot 2021-08-15 at 4 18 49 pm" src="https://user-images.githubusercontent.com/5115928/129469187-a4bfaeca-992a-496c-b8d7-e9d9bd0dd035.png">

### Inventory Lists Page Showing Editable and Non-Editable Lists

<img width="1024" alt="Screen Shot 2021-08-15 at 4 19 09 pm" src="https://user-images.githubusercontent.com/5115928/129469190-6d786fe2-4dd2-42df-8a26-1f8be2e962d3.png">

