### PR TITLE
Enable inventory list items to be destroyed from the UI

### DIFF
--- a/src/components/inventoryListItem/inventoryListItem.js
+++ b/src/components/inventoryListItem/inventoryListItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
-import { faAngleUp, faAngleDown } from '@fortawesome/free-solid-svg-icons'
+import { faAngleUp, faAngleDown, faTimes } from '@fortawesome/free-solid-svg-icons'
 import SlideToggle from 'react-slide-toggle'
 import { useAppContext, useInventoryListsContext, useColorScheme } from '../../hooks/contexts'
 import withModal from '../../hocs/withModal'
@@ -48,6 +48,7 @@ const InventoryListItem = ({
 
   const mountedRef = useRef(true)
   const editRef = useRef(null)
+  const deleteRef = useRef(null)
   const incRef = useRef(null)
   const decRef = useRef(null)
 
@@ -64,7 +65,7 @@ const InventoryListItem = ({
   } = useColorScheme()
 
   const refContains = (ref, el) => ref.current && (ref.current === el || ref.current.contains(el))
-  const iconContains = el => refContains(incRef, el) || refContains(decRef, el) || refContains(editRef, el)
+  const iconContains = el => refContains(incRef, el) || refContains(decRef, el) || refContains(editRef, el) || refContains(deleteRef, el)
 
   const shouldToggleDetails = element => !iconContains(element)
 
@@ -146,6 +147,23 @@ const InventoryListItem = ({
     }
   }
 
+  const destroyItem = () => {
+    const confirmed = window.confirm("Destroy inventory list item? Your All Items list will be updated to reflect the change. This cannot be undone.")
+
+    if (confirmed) {
+      const callbacks = {
+        onSuccess: () => mountedRef.current = false,
+        onUnauthorized: () => mountedRef.current = false,
+        onNotFound: () => setFlashVisible(true),
+        onInternalServerError: () => setFlashVisible(true)
+      }
+
+      performInventoryListItemDestroy(itemId, callbacks)
+    } else {
+      displayFlash('info', 'Your item was not deleted.')
+    }
+  }
+
   const showEditForm = () => {
     if (!mountedRef.current) return
 
@@ -191,6 +209,9 @@ const InventoryListItem = ({
         <span className={classNames(styles.header, { [styles.headerEditable]: canEdit })}>
           {canEdit &&
           <span className={styles.editIcons}>
+            <button className={styles.icon} ref={deleteRef} onClick={destroyItem} data-testid='destroy-item'>
+              <FontAwesomeIcon className={classNames(styles.fa, styles.destroyIcon)} icon={faTimes} />
+            </button>
             <button className={styles.icon} ref={editRef} onClick={showEditForm} data-testid='edit-item'>
               <FontAwesomeIcon className={styles.fa} icon={faEdit} />
             </button>


### PR DESCRIPTION
## Context

[**Enable user to destroy inventory list items from the front end**](https://trello.com/c/VOk54oUZ/151-enable-user-to-destroy-inventory-list-items-from-the-front-end)

Currently, the only way to remove an inventory list item from the front end is to decrement its quantity to zero and delete when prompted. It would be better to be able to delete inventory list items without having to decrement a potentially large number of times.

## Changes

* New icon to destroy inventory list items
* Tests for new functionality

## Screenshots and GIFs

### 1201px

![issue-151_1201px](https://user-images.githubusercontent.com/5115928/130337764-27cf6eb2-f289-45c5-b42f-4db4607fe47e.png)

### 1025px

![issue-151_1025px](https://user-images.githubusercontent.com/5115928/130337767-2a6bdedb-941b-4c49-9263-d1b6ae51f113.png)

### 769px

![issue-151_769px](https://user-images.githubusercontent.com/5115928/130337769-076752e2-d6c3-4c5f-bf1a-2ef31d4a6f1d.png)

### 601px

![issue-151_601px](https://user-images.githubusercontent.com/5115928/130337770-d58959a1-2919-4892-b58c-71379f8f3680.png)

### 425px

![issue-151_425px](https://user-images.githubusercontent.com/5115928/130337773-ea096f54-6e25-4cc4-9ad3-6ea1b3c4ad6e.png)

