### PR TITLE
Update simApi module (and stories) to point to correct endpoints

### DIFF
--- a/src/components/inventoryPageContent/inventoryPageContent.stories.js
+++ b/src/components/inventoryPageContent/inventoryPageContent.stories.js
@@ -90,8 +90,8 @@ HappyPath.parameters = {
         // If there is a matching item on the aggregate list, that item will be updated as
         // described above. If there is no matching item, a new one will be created with
         // the `notes` and `description` values from the request.
-        const description = req.body.inventory_list_item.description
-        const quantity = req.body.inventory_list_item.quantity || '1'
+        const description = req.body.inventory_item.description
+        const quantity = req.body.inventory_item.quantity || '1'
 
         // Description and quantity are both required and neither can be blank. The
         // quantity must be an integer as well. If the quantity is a decimal/float value
@@ -99,7 +99,7 @@ HappyPath.parameters = {
         // quantity is non-numeric or less than 1, it is invalid.
         if (description && quantity && (typeof quantity === 'number' || quantity.match(/[1-9]+(\.\d+)?/))) {
           const regListItem = regList.list_items.find(item => item.description.toLowerCase() === description.toLowerCase())
-          const notes = req.body.inventory_list_item.notes
+          const notes = req.body.inventory_item.notes
 
           const aggregateList = findAggregateList(allInventoryLists, regList.game_id)
           const aggregateListItem = aggregateList.list_items.find(item => item.description.toLowerCase() === description.toLowerCase())
@@ -156,7 +156,7 @@ HappyPath.parameters = {
         // edit form will not appear if you click the update link.
         const existingItem = regList.list_items.find(item => item.id === itemId)
         const aggregateList = findAggregateList(allInventoryLists, regList.game_id)
-        const newItem = { ...existingItem, ...req.body.inventory_list_item }
+        const newItem = { ...existingItem, ...req.body.inventory_item }
         const quantity = parseInt(newItem.quantity)
 
         if (newItem.unit_weight === null || newItem.unit_weight === undefined || newItem.unit_weight === '') {

--- a/src/components/inventoryPageContent/inventoryPageContent.stories.js
+++ b/src/components/inventoryPageContent/inventoryPageContent.stories.js
@@ -53,7 +53,7 @@ HappyPath.parameters = {
       const listId = parseInt(req.params.id)
       const regularList = allInventoryLists.find(list => list.id === listId)
       const items = regularList.list_items
-      
+
       const newAggregateList = removeOrAdjustItemsOnListDestroy(allInventoryLists[0], items)
 
       if (newAggregateList === null) {
@@ -71,7 +71,7 @@ HappyPath.parameters = {
     // list exists and belongs to the authenticated user. For the purposes of Storybook, we
     // assume the user is authenticated and the `allInventoryLists` array represents all their
     // inventory lists for all their games.
-    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
       // Find the inventory list the user wants to add the item to
       const listId = parseInt(req.params.listId)
       const regList = allInventoryLists.find(list => list.id === listId)
@@ -143,7 +143,7 @@ HappyPath.parameters = {
     // item exists and belongs to the authenticated user. For the purposes of
     // Storybook, we assume the user is authenticated and the `allInventoryLists`
     // array represents all their lists for all their games.
-    rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+    rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
       // Find the list the item is on
       const itemId = parseInt(req.params.id)
       const regList = findListByListItem(allInventoryLists, itemId)
@@ -158,7 +158,7 @@ HappyPath.parameters = {
         const aggregateList = findAggregateList(allInventoryLists, regList.game_id)
         const newItem = { ...existingItem, ...req.body.inventory_list_item }
         const quantity = parseInt(newItem.quantity)
-        
+
         if (newItem.unit_weight === null || newItem.unit_weight === undefined || newItem.unit_weight === '') {
           newItem.unit_weight = null
         } else {
@@ -196,7 +196,7 @@ HappyPath.parameters = {
     // belongs to the authenticated user. For the purposes of Storybook, we're
     // assuming that the user is authenticated and the `allInventoryLists` array
     // represents all their inventory lists for all their games.
-    rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+    rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
       // Find the item and the list it is on.
       const itemId = parseInt(req.params.id)
       const regList = findListByListItem(allInventoryLists, itemId)

--- a/src/pages/inventoryPage/__tests__/listItems/createListItem401.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/createListItem401.test.js
@@ -39,7 +39,7 @@ describe('Creating a inventory list item - when the server returns a 401', () =>
   }
 
   const server = setupServer(
-    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
       return res(
         ctx.status(401),
         ctx.json({

--- a/src/pages/inventoryPage/__tests__/listItems/createListItem404.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/createListItem404.test.js
@@ -39,7 +39,7 @@ describe('Creating a inventory list item - when the server returns a 404', () =>
   }
 
   const server = setupServer(
-    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
       return res(
         ctx.status(404)
       )

--- a/src/pages/inventoryPage/__tests__/listItems/createListItem422.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/createListItem422.test.js
@@ -39,7 +39,7 @@ describe('Creating a inventory list item when the attributes are invalid', () =>
   }
 
   const server = setupServer(
-    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
       return res(
         ctx.status(422),
         ctx.json({

--- a/src/pages/inventoryPage/__tests__/listItems/createListItem500.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/createListItem500.test.js
@@ -39,7 +39,7 @@ describe('Creating an inventory list item when the server returns a 500', () => 
   }
 
   const server = setupServer(
-    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
       return res(
         ctx.status(500),
         ctx.json({

--- a/src/pages/inventoryPage/__tests__/listItems/createListItemHappyPath.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/createListItemHappyPath.test.js
@@ -43,7 +43,7 @@ describe('Creating a inventory list item - happy path', () => {
 
   describe('when there is no matching item on any inventory list', () => {
     const server = setupServer(
-      rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+      rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
         const listId = parseInt(req.params.listId)
         const description = req.body.inventory_list_item.description
         const quantity = req.body.inventory_list_item.quantity
@@ -149,7 +149,7 @@ describe('Creating a inventory list item - happy path', () => {
 
   describe('when there is a matching item on another list', () => {
     const server = setupServer(
-      rest.post(`${backendBaseUri}/inventory_lists/${allInventoryLists[2].id}/inventory_list_items`, (req, res, ctx) => {
+      rest.post(`${backendBaseUri}/inventory_lists/${allInventoryLists[2].id}/inventory_items`, (req, res, ctx) => {
         const listId = allInventoryLists[2].id
         const description = req.body.inventory_list_item.description
         const quantity = req.body.inventory_list_item.quantity
@@ -241,7 +241,7 @@ describe('Creating a inventory list item - happy path', () => {
       const itemEl = item.closest('.root')
 
       expect(item).toBeVisible()
-      
+
       fireEvent.click(item)
 
       await waitFor(() => expect(within(itemEl).queryByText('9')).toBeVisible())
@@ -252,7 +252,7 @@ describe('Creating a inventory list item - happy path', () => {
 
   describe('when there is a matching item on the same list', () => {
     const server = setupServer(
-      rest.post(`${backendBaseUri}/inventory_lists/${allInventoryLists[1].id}/inventory_list_items`, (req, res, ctx) => {
+      rest.post(`${backendBaseUri}/inventory_lists/${allInventoryLists[1].id}/inventory_items`, (req, res, ctx) => {
         const listId = allInventoryLists[1].id
         const description = req.body.inventory_list_item.description
         const quantity = req.body.inventory_list_item.quantity

--- a/src/pages/inventoryPage/__tests__/listItems/createListItemHappyPath.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/createListItemHappyPath.test.js
@@ -45,10 +45,10 @@ describe('Creating a inventory list item - happy path', () => {
     const server = setupServer(
       rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
         const listId = parseInt(req.params.listId)
-        const description = req.body.inventory_list_item.description
-        const quantity = req.body.inventory_list_item.quantity
-        const unit_weight = req.body.inventory_list_item.unit_weight
-        const notes = req.body.inventory_list_item.notes
+        const description = req.body.inventory_item.description
+        const quantity = req.body.inventory_item.quantity
+        const unit_weight = req.body.inventory_item.unit_weight
+        const notes = req.body.inventory_item.notes
 
         const json = [
           {
@@ -151,10 +151,10 @@ describe('Creating a inventory list item - happy path', () => {
     const server = setupServer(
       rest.post(`${backendBaseUri}/inventory_lists/${allInventoryLists[2].id}/inventory_items`, (req, res, ctx) => {
         const listId = allInventoryLists[2].id
-        const description = req.body.inventory_list_item.description
-        const quantity = req.body.inventory_list_item.quantity
-        const unit_weight = Number(req.body.inventory_list_item.unit_weight)
-        const notes = req.body.inventory_list_item.notes
+        const description = req.body.inventory_item.description
+        const quantity = req.body.inventory_item.quantity
+        const unit_weight = Number(req.body.inventory_item.unit_weight)
+        const notes = req.body.inventory_item.notes
 
         const allItemsListItem = allInventoryLists[0].list_items.find(item => item.description.toLowerCase() === description.toLowerCase())
 
@@ -254,9 +254,9 @@ describe('Creating a inventory list item - happy path', () => {
     const server = setupServer(
       rest.post(`${backendBaseUri}/inventory_lists/${allInventoryLists[1].id}/inventory_items`, (req, res, ctx) => {
         const listId = allInventoryLists[1].id
-        const description = req.body.inventory_list_item.description
-        const quantity = req.body.inventory_list_item.quantity
-        const notes = req.body.inventory_list_item.notes
+        const description = req.body.inventory_item.description
+        const quantity = req.body.inventory_item.quantity
+        const notes = req.body.inventory_item.notes
 
         const regularListItem = allInventoryLists[1].list_items.find(item => item.description.toLowerCase() === description.toLowerCase())
         const allItemsListItem = allInventoryLists[0].list_items.find(item => item.description.toLowerCase() === description.toLowerCase())

--- a/src/pages/inventoryPage/__tests__/listItems/decrementListItemHappyPath.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/decrementListItemHappyPath.test.js
@@ -42,7 +42,7 @@ describe('Decrementing an inventory list item - happy path', () => {
 
   describe('when the new quantity would be greater than zero', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/3`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/3`, (req, res, ctx) => {
         const listItem = allInventoryLists[1].list_items[1]
         const aggListItem = allInventoryLists[0].list_items.find(item => item.description.toLowerCase() === listItem.description.toLowerCase())
         const quantity = req.body.inventory_list_item.quantity
@@ -112,7 +112,7 @@ describe('Decrementing an inventory list item - happy path', () => {
       await waitFor(() => expect(within(aggListItemEl).queryByText('3')).toBeVisible())
     })
   })
-  
+
   describe('when the new quantity would be zero', () => {
     let confirm
 
@@ -154,7 +154,7 @@ describe('Decrementing an inventory list item - happy path', () => {
     describe('when the user deletes the item when prompted', () => {
       describe('when the item on the aggregate list is not destroyed', () => {
         const server = setupServer(
-          rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+          rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
             const itemId = parseInt(req.params.id)
             const regList = allInventoryLists.find(list => !!list.list_items.find(li => li.id === itemId))
             const regListItem = regList.list_items.find(li => li.id === itemId)
@@ -171,7 +171,7 @@ describe('Decrementing an inventory list item - happy path', () => {
             )
           })
         )
-        
+
         beforeAll(() => server.listen())
 
         beforeEach(() => {
@@ -211,7 +211,7 @@ describe('Decrementing an inventory list item - happy path', () => {
           // Find the aggregate list
           const aggListTitleEl = await screen.findByText('All Items')
           const aggListEl = aggListTitleEl.closest('.root')
-          
+
           // Expand the aggregate list
           fireEvent.click(aggListTitleEl)
 
@@ -226,7 +226,7 @@ describe('Decrementing an inventory list item - happy path', () => {
 
       describe('when the item on the aggregate list is destroyed', () => {
         const server = setupServer(
-          rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+          rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
             return res(
               ctx.status(204)
             )
@@ -273,7 +273,7 @@ describe('Decrementing an inventory list item - happy path', () => {
           // Find the aggregate list
           const aggListTitleEl = await screen.findByText('All Items')
           const aggListEl = aggListTitleEl.closest('.root')
-          
+
           // Expand the aggregate list
           fireEvent.click(aggListTitleEl)
 

--- a/src/pages/inventoryPage/__tests__/listItems/decrementListItemHappyPath.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/decrementListItemHappyPath.test.js
@@ -45,7 +45,7 @@ describe('Decrementing an inventory list item - happy path', () => {
       rest.patch(`${backendBaseUri}/inventory_items/3`, (req, res, ctx) => {
         const listItem = allInventoryLists[1].list_items[1]
         const aggListItem = allInventoryLists[0].list_items.find(item => item.description.toLowerCase() === listItem.description.toLowerCase())
-        const quantity = req.body.inventory_list_item.quantity
+        const quantity = req.body.inventory_item.quantity
         const deltaQty = quantity - listItem.quantity
 
         const returnJson = [

--- a/src/pages/inventoryPage/__tests__/listItems/destroyInventoryListItem.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/destroyInventoryListItem.test.js
@@ -95,7 +95,7 @@ describe('Destroying a inventory list item', () => {
 
   describe('when the aggregate list item is also removed', () => {
     const server = setupServer(
-      rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(204)
         )
@@ -156,7 +156,7 @@ describe('Destroying a inventory list item', () => {
 
   describe('when the aggregate list item is not removed', () => {
     const server = setupServer(
-      rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         const itemId = parseInt(req.params.id)
         const list = findListByListItem(allInventoryLists, itemId)
         const item = list.list_items.find(i => i.id === itemId)
@@ -224,7 +224,7 @@ describe('Destroying a inventory list item', () => {
 
   describe('when the server returns a 401 error', () => {
     const server = setupServer(
-      rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(401),
           ctx.json({
@@ -270,7 +270,7 @@ describe('Destroying a inventory list item', () => {
 
   describe('when the server returns a 404 error', () => {
     const server = setupServer(
-      rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(404)
         )
@@ -326,7 +326,7 @@ describe('Destroying a inventory list item', () => {
 
   describe('when the server returns a 500 error', () => {
     const server = setupServer(
-      rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(500),
           ctx.json({

--- a/src/pages/inventoryPage/__tests__/listItems/incrementDecrementErrorCases.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/incrementDecrementErrorCases.test.js
@@ -43,7 +43,7 @@ describe('Incrementing or decrementing an inventory list item - error cases', ()
 
   describe('when the server returns a 401', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/3`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/3`, (req, res, ctx) => {
         return res(
           ctx.status(401),
           ctx.json({
@@ -51,7 +51,7 @@ describe('Incrementing or decrementing an inventory list item - error cases', ()
           })
         )
       }),
-      rest.delete(`${backendBaseUri}/inventory_list_items/6`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/inventory_items/6`, (req, res, ctx) => {
         return res(
           ctx.status(401),
           ctx.json({
@@ -142,12 +142,12 @@ describe('Incrementing or decrementing an inventory list item - error cases', ()
 
   describe('when the server returns a 404', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(404)
         )
       }),
-      rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(404)
         )
@@ -244,7 +244,7 @@ describe('Incrementing or decrementing an inventory list item - error cases', ()
 
     describe('decrementing to zero', () => {
       let confirm
-      
+
       beforeEach(() => {
         confirm = jest.spyOn(window, 'confirm').mockImplementation(() => true)
       })
@@ -289,7 +289,7 @@ describe('Incrementing or decrementing an inventory list item - error cases', ()
 
   describe('when the server returns a 500 or other error', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(500),
           ctx.json({
@@ -297,7 +297,7 @@ describe('Incrementing or decrementing an inventory list item - error cases', ()
           })
         )
       }),
-      rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(500),
           ctx.json({

--- a/src/pages/inventoryPage/__tests__/listItems/incrementListItemHappyPath.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/incrementListItemHappyPath.test.js
@@ -42,7 +42,7 @@ describe('Incrementing an inventory list item - happy path', () => {
     rest.patch(`${backendBaseUri}/inventory_items/3`, (req, res, ctx) => {
       const listItem = allInventoryLists[1].list_items[1]
       const aggListItem = allInventoryLists[0].list_items.find(item => item.description.toLowerCase() === listItem.description.toLowerCase())
-      const quantity = req.body.inventory_list_item.quantity
+      const quantity = req.body.inventory_item.quantity
       const deltaQty = quantity - listItem.quantity
 
       const returnJson = [

--- a/src/pages/inventoryPage/__tests__/listItems/incrementListItemHappyPath.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/incrementListItemHappyPath.test.js
@@ -39,7 +39,7 @@ describe('Incrementing an inventory list item - happy path', () => {
   }
 
   const server = setupServer(
-    rest.patch(`${backendBaseUri}/inventory_list_items/3`, (req, res, ctx) => {
+    rest.patch(`${backendBaseUri}/inventory_items/3`, (req, res, ctx) => {
       const listItem = allInventoryLists[1].list_items[1]
       const aggListItem = allInventoryLists[0].list_items.find(item => item.description.toLowerCase() === listItem.description.toLowerCase())
       const quantity = req.body.inventory_list_item.quantity

--- a/src/pages/inventoryPage/__tests__/listItems/updateInventoryListItemErrorCases.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/updateInventoryListItemErrorCases.test.js
@@ -43,7 +43,7 @@ describe('Updating an inventory list item - error cases', () => {
 
   describe('when the server returns a 401 error', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(401),
           ctx.json({
@@ -95,7 +95,7 @@ describe('Updating an inventory list item - error cases', () => {
 
   describe('when the server returns a 404 error', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(404)
         )
@@ -137,7 +137,7 @@ describe('Updating an inventory list item - error cases', () => {
       // Submit the form
       fireEvent.submit(form)
 
-      // The form should be hidden 
+      // The form should be hidden
       await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // Now we need to find the item on the regular list and the
@@ -168,7 +168,7 @@ describe('Updating an inventory list item - error cases', () => {
 
   describe('when the server returns a 422 error', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(422),
           ctx.json({
@@ -216,7 +216,7 @@ describe('Updating an inventory list item - error cases', () => {
       // Submit the form
       fireEvent.submit(form)
 
-      // The form should not be hidden 
+      // The form should not be hidden
       await waitFor(() => expect(form).toBeInTheDocument())
 
       // Now we need to find the item on the regular list and the
@@ -243,7 +243,7 @@ describe('Updating an inventory list item - error cases', () => {
 
   describe('when the server returns a 500 error', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
         return res(
           ctx.status(500),
           ctx.json({
@@ -286,7 +286,7 @@ describe('Updating an inventory list item - error cases', () => {
       // Submit the form
       fireEvent.submit(form)
 
-      // The form should be hidden 
+      // The form should be hidden
       await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // Now we need to find the item on the regular list and the

--- a/src/pages/inventoryPage/__tests__/listItems/updateInventoryListItemHappyPath.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/updateInventoryListItemHappyPath.test.js
@@ -46,8 +46,8 @@ describe('Updating an inventory list item - happy path', () => {
       rest.patch(`${backendBaseUri}/inventory_items/3`, (req, res, ctx) => {
         const listItem = allInventoryLists[1].list_items[1]
         const aggListItem = allInventoryLists[0].list_items.find(item => item.description.toLowerCase() === listItem.description.toLowerCase())
-        const quantity = parseInt(req.body.inventory_list_item.quantity)
-        const notes = req.body.inventory_list_item.notes
+        const quantity = parseInt(req.body.inventory_item.quantity)
+        const notes = req.body.inventory_item.notes
 
         const returnJson = [
           {

--- a/src/pages/inventoryPage/__tests__/listItems/updateInventoryListItemHappyPath.test.js
+++ b/src/pages/inventoryPage/__tests__/listItems/updateInventoryListItemHappyPath.test.js
@@ -43,7 +43,7 @@ describe('Updating an inventory list item - happy path', () => {
 
   describe('when not updating unit weight', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/3`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/3`, (req, res, ctx) => {
         const listItem = allInventoryLists[1].list_items[1]
         const aggListItem = allInventoryLists[0].list_items.find(item => item.description.toLowerCase() === listItem.description.toLowerCase())
         const quantity = parseInt(req.body.inventory_list_item.quantity)
@@ -105,7 +105,7 @@ describe('Updating an inventory list item - happy path', () => {
       // Submit the form
       fireEvent.submit(form)
 
-      // The form should be hidden 
+      // The form should be hidden
       await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // Now we need to find the item on the regular list and the
@@ -159,7 +159,7 @@ describe('Updating an inventory list item - happy path', () => {
         // Now press the escape key to hide the modal
         fireEvent.keyDown(form, { key: 'Escape', code: 'Escape' })
 
-        // The form should be hidden 
+        // The form should be hidden
         await waitFor(() => expect(modal).not.toBeVisible())
       })
     })
@@ -190,7 +190,7 @@ describe('Updating an inventory list item - happy path', () => {
         // Now click on the modal element, outside the form, to hide it
         fireEvent.click(modal)
 
-        // The form should be hidden 
+        // The form should be hidden
         await waitFor(() => expect(modal).not.toBeVisible())
       })
     })
@@ -198,7 +198,7 @@ describe('Updating an inventory list item - happy path', () => {
 
   describe('when updating unit weight', () => {
     const server = setupServer(
-      rest.patch(`${backendBaseUri}/inventory_list_items/1`, (req, res, ctx) => {
+      rest.patch(`${backendBaseUri}/inventory_items/1`, (req, res, ctx) => {
         const lists = allInventoryLists.filter(list => list.game_id === games[0].id)
 
         let response = []
@@ -250,7 +250,7 @@ describe('Updating an inventory list item - happy path', () => {
       // Submit the form
       fireEvent.submit(form)
 
-      // The form should be hidden 
+      // The form should be hidden
       await waitFor(() => expect(form).not.toBeInTheDocument())
 
       // Now we need to find the item on all the lists where it appears.

--- a/src/pages/inventoryPage/inventoryPage.stories.js
+++ b/src/pages/inventoryPage/inventoryPage.stories.js
@@ -23,14 +23,14 @@ import InventoryPage from './inventoryPage'
 
 export default { title: 'InventoryPage' }
 
-/* 
- * 
+/*
+ *
  * When the user is logged in, has inventory lists, and the inventory
  * lists are able to be created or updated without incident. Also tests that,
  * when a user assigns a blank title and the API response returns a default
  * one, the title first stays blank then updates to the default one when the
  * response comes back.
- * 
+ *
  */
 
 export const HappyPath = () => (
@@ -205,7 +205,7 @@ HappyPath.parameters = {
     // list exists and belongs to the authenticated user. For the purposes of Storybook, we
     // assume the user is authenticated and the `allInventoryLists` array represents all their
     // inventory lists for all their games.
-    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
       // Find the inventory list the user wants to add the item to
       const listId = parseInt(req.params.listId)
       const regList = allInventoryLists.find(list => list.id === listId)
@@ -284,14 +284,14 @@ HappyPath.parameters = {
     // item exists and belongs to the authenticated user. For the purposes of
     // Storybook, we assume the user is authenticated and the `allInventoryLists`
     // array represents all their inventory lists for all their games.
-    rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+    rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
       // Find the list the item is on
       const itemId = parseInt(req.params.id)
       const regList = findListByListItem(allInventoryLists, itemId)
 
       if (regList) {
         // If the required `description` field isn't blank, find the item and the
-        // aggregate list the item is on. The corresponding item on that list 
+        // aggregate list the item is on. The corresponding item on that list
         // will need to be updated as well.
         const existingItem = regList.list_items.find(item => item.id === itemId)
         const aggregateList = findAggregateList(allInventoryLists, regList.game_id)
@@ -330,7 +330,7 @@ HappyPath.parameters = {
     // belongs to the authenticated user. For the purposes of Storybook, we're
     // assuming that the user is authenticated and the `allInventoryLists` array
     // represents all their inventory lists for all their games.
-    rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+    rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
       // Find the item and the list it is on.
       const itemId = parseInt(req.params.id)
       const regList = findListByListItem(allInventoryLists, itemId)
@@ -498,17 +498,17 @@ GameNotFoundOnCreate.parameters = {
         ctx.status(404)
       )
     }),
-    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
       return res(
         ctx.status(404)
       )
     }),
-    rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+    rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
       return res(
         ctx.status(404)
       )
     }),
-    rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+    rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
       return res(
         ctx.status(404)
       )
@@ -609,7 +609,7 @@ ListOrItemNotFound.parameters = {
     // on a list after deleting the list on another device or browser. The API would return
     // a 404 and the UI should display a message telling the user the list could not be found
     // and advising them to refresh their browser.
-    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_list_items`, (req, res, ctx) => {
+    rest.post(`${backendBaseUri}/inventory_lists/:listId/inventory_items`, (req, res, ctx) => {
       return res(
         ctx.status(404)
       )
@@ -618,7 +618,7 @@ ListOrItemNotFound.parameters = {
     // after deleting the list item on another device or browser. The API would return a
     // 404 and the UI should display a message telling the user the item could not be found
     // and advising them to refresh their browser.
-    rest.patch(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+    rest.patch(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
       return res(
         ctx.status(404)
       )
@@ -627,7 +627,7 @@ ListOrItemNotFound.parameters = {
     // after deleting the list item on another device or browser. The API would return a
     // 404 and the UI should display a message telling the user the list could not be found
     // and advising them to refresh their browser.
-    rest.delete(`${backendBaseUri}/inventory_list_items/:id`, (req, res, ctx) => {
+    rest.delete(`${backendBaseUri}/inventory_items/:id`, (req, res, ctx) => {
       return res(
         ctx.status(404)
       )
@@ -638,7 +638,7 @@ ListOrItemNotFound.parameters = {
 /*
  *
  * When the game has no inventory lists
- * 
+ *
  */
 
 export const NoLists = () => (

--- a/src/pages/inventoryPage/inventoryPage.stories.js
+++ b/src/pages/inventoryPage/inventoryPage.stories.js
@@ -224,13 +224,13 @@ HappyPath.parameters = {
         // If there is a matching item on the aggregate list, that item will be updated as
         // described above. If there is no matching item, a new one will be created with
         // the `notes` and `description` values from the request.
-        const description = req.body.inventory_list_item.description
-        const quantity = req.body.inventory_list_item.quantity || '1'
+        const description = req.body.inventory_item.description
+        const quantity = req.body.inventory_item.quantity || '1'
 
         // We're not going to do syncing of unit weights in this story. It's
         // just too complicated. If a unit weight is set in Storybook, it'll only
         // be set for the new item and the aggregate list item.
-        let unit_weight = req.body.inventory_list_item.unit_weight
+        let unit_weight = req.body.inventory_item.unit_weight
         if (unit_weight === null || unit_weight === undefined || unit_weight === '') {
           unit_weight = null
         } else {
@@ -243,7 +243,7 @@ HappyPath.parameters = {
         // quantity is non-numeric or less than 1, it is invalid.
         if (description && quantity && (typeof quantity === 'number' || quantity.match(/[1-9]+(\.\d+)?/))) {
           const regListItem = regList.list_items.find(item => item.description.toLowerCase() === description.toLowerCase())
-          const notes = req.body.inventory_list_item.notes
+          const notes = req.body.inventory_item.notes
 
           const aggregateList = findAggregateList(allInventoryLists, regList.game_id)
           const aggregateListItem = aggregateList.list_items.find(item => item.description.toLowerCase() === description.toLowerCase())
@@ -295,7 +295,7 @@ HappyPath.parameters = {
         // will need to be updated as well.
         const existingItem = regList.list_items.find(item => item.id === itemId)
         const aggregateList = findAggregateList(allInventoryLists, regList.game_id)
-        const newItem = { ...existingItem, ...req.body.inventory_list_item }
+        const newItem = { ...existingItem, ...req.body.inventory_item }
 
         if (parseInt(newItem.quantity) > 0) {
           const deltaQuantity = newItem.quantity - existingItem.quantity
@@ -303,7 +303,7 @@ HappyPath.parameters = {
             item.description.toLowerCase() === existingItem.description.toLowerCase()
           ))
 
-          const unitWeight = req.body.inventory_list_item.unit_weight
+          const unitWeight = req.body.inventory_item.unit_weight
 
           adjustListItem(aggregateListItem, deltaQuantity, existingItem.notes, newItem.notes, unitWeight)
 

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -6,11 +6,11 @@
  * headers and request body) and (2) throwing an AuthorizationError if the request fails.
  * The AuthorizationError has name 'AuthorizationError', code 401, and either the
  * message passed to the constructor or, by default, '401 Unauthorized'.
- * 
+ *
  * For more information on the SIM API, its endpoints, the requests it expects, or its
  * responses, please visit the backend API docs:
  * https://github.com/danascheider/skyrim_inventory_management/tree/main/docs/api
- * 
+ *
  */
 
 import { backendBaseUri } from './config'
@@ -27,7 +27,7 @@ const combinedHeaders = token => ({ ...authHeader(token), ...contentTypeHeader }
 /*
  *
  * Google OAuth Token Verification Endpoint
- * 
+ *
  */
 
 export const authorize = token => {
@@ -45,7 +45,7 @@ export const authorize = token => {
 /*
  *
  * User Profile Endpoint
- * 
+ *
  */
 
 export const fetchUserProfile = token => {
@@ -63,7 +63,7 @@ export const fetchUserProfile = token => {
 /*
  *
  * Game Endpoints (Scoped to Authenticated User)
- * 
+ *
  */
 
 // GET /games
@@ -277,7 +277,7 @@ export const destroyShoppingListItem = (token, itemId) => {
 /*
  *
  * Inventory List Endpoints (Scoped to Game)
- * 
+ *
  */
 
 // GET /games/:game_id/inventory_lists
@@ -352,9 +352,9 @@ export const destroyInventoryList = (token, listId) => {
  *
  */
 
-// POST /inventory_lists/:list_id/inventory_list_items
+// POST /inventory_lists/:list_id/inventory_items
 export const createInventoryListItem = (token, listId, attrs) => {
-  const uri = `${backendBaseUri}/inventory_lists/${listId}/inventory_list_items`
+  const uri = `${backendBaseUri}/inventory_lists/${listId}/inventory_items`
   const body = JSON.stringify({ inventory_list_item: attrs })
 
   return(
@@ -368,9 +368,9 @@ export const createInventoryListItem = (token, listId, attrs) => {
   )
 }
 
-// PATCH /inventory_list_items/:id
+// PATCH /inventory_items/:id
 export const updateInventoryListItem = (token, itemId, attrs) => {
-  const uri = `${backendBaseUri}/inventory_list_items/${itemId}`
+  const uri = `${backendBaseUri}/inventory_items/${itemId}`
   const body = JSON.stringify({ inventory_list_item: attrs })
 
   return(
@@ -378,15 +378,15 @@ export const updateInventoryListItem = (token, itemId, attrs) => {
       .then(resp => {
         if (resp.status === 401) throw new AuthorizationError()
         if (resp.status === 404) throw new NotFoundError()
-        
+
         return resp.json().then(json => ({ status: resp.status, json }))
       })
   )
 }
 
-// DELETE /inventory_list_items/:id
+// DELETE /inventory_items/:id
 export const destroyInventoryListItem = (token, itemId) => {
-  const uri = `${backendBaseUri}/inventory_list_items/${itemId}`
+  const uri = `${backendBaseUri}/inventory_items/${itemId}`
 
   return(
     fetch(uri, { method: 'DELETE', headers: authHeader(token) })

--- a/src/utils/simApi.js
+++ b/src/utils/simApi.js
@@ -355,7 +355,7 @@ export const destroyInventoryList = (token, listId) => {
 // POST /inventory_lists/:list_id/inventory_items
 export const createInventoryListItem = (token, listId, attrs) => {
   const uri = `${backendBaseUri}/inventory_lists/${listId}/inventory_items`
-  const body = JSON.stringify({ inventory_list_item: attrs })
+  const body = JSON.stringify({ inventory_item: attrs })
 
   return(
     fetch(uri, { method: 'POST', headers: combinedHeaders(token), body })
@@ -371,7 +371,7 @@ export const createInventoryListItem = (token, listId, attrs) => {
 // PATCH /inventory_items/:id
 export const updateInventoryListItem = (token, itemId, attrs) => {
   const uri = `${backendBaseUri}/inventory_items/${itemId}`
-  const body = JSON.stringify({ inventory_list_item: attrs })
+  const body = JSON.stringify({ inventory_item: attrs })
 
   return(
     fetch(uri, { method: 'PATCH', headers: combinedHeaders(token), body })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4725,9 +4725,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001219:
-  version "1.0.30001248"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz#26ab45e340f155ea5da2920dadb76a533cb8ebce"
-  integrity sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==
+  version "1.0.30001342"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz"
+  integrity sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==
 
 canvas@^2.8.0:
   version "2.8.0"


### PR DESCRIPTION
## Context

During local testing, we determined we missed some spots when configuring the `simApi` module to contact the correct endpoints for inventory list items, which are now called `inventory_items` on the backend. Not only had we missed several endpoints, but all the stories and tests also pointed to the deprecated/renamed endpoints. This caused things to blow up during testing.

## Changes

* Change `inventory_list_items` API endpoints to `inventory_items`
* Change `inventory_list_item` key expected in response bodies to `inventory_item`

## Manual Test Cases

All CRUD actions on inventory list items should be tested. 
