### PR TITLE
Remove deprecated option from tsconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         node-version: "23.2.0"
     - name: Install Node Modules
       run: yarn
+    - name: Compile Production Build
+      run: yarn build
     - name: lint
       run: yarn lint
     - name: format

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Context

[**Figure out problems with new TypeScript version preventing deploy**](https://trello.com/c/y0iaGylr/419-figure-out-problems-with-new-typescript-version-preventing-deploy)

The `esModuleInterop` option has been deprecated in TypeScript 6 and will stop functioning in TypeScript 7.0. We need to remove this from tsconfig.

We discovered this issue when `yarn build` failed during a Firebase deploy. We are currently not running a `yarn build` step in CI, and this has bitten us more than once.

## Changes

* Remove `esModuleInterop` option from tsconfig
* Update GitHub Actions to include a `yarn build` step in CI

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [x] Comprehensively test final changes in local environment
- [ ] ~~Add/update docs~~
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles